### PR TITLE
Switch to SDCLI for the binary build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
-FROM golang:latest AS BUILDER
+FROM asecurityteam/sdcli:v1 AS BUILDER
+RUN mkdir -p /go/src/github.com/asecurityteam/transportd
 WORKDIR /go/src/github.com/asecurityteam/transportd
-COPY . .
+COPY --chown=sdcli:sdcli . .
+RUN sdcli go dep
 RUN CGO_ENABLED=0 GOOS=linux go build -a -o /opt/app main.go
 
 ##################################
@@ -16,9 +18,7 @@ RUN zip -r -0 /zoneinfo.zip .
 
 FROM scratch
 COPY --from=BUILDER /opt/app .
-# the timezone data:
 COPY --from=CERTS /zoneinfo.zip /
-# the tls certificates:
 COPY --from=CERTS /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 ENV ZONEINFO /zoneinfo.zip


### PR DESCRIPTION
This introduces SDCLI for the BUILDER stage of the Dockerfile that
generates the compiled binary.