### PR TITLE
patch OpenAPI library breaking change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -988,3 +988,5 @@ ASALocalRun/
 
 
 # End of https://www.gitignore.io/api/go,vim,osx,java,node,emacs,linux,xcode,maven,macos,python,windows,eclipse,intellij,jetbrains,virtualenv,sublimetext,visualstudio,visualstudiocode
+
+transportd

--- a/pkg/clienttransport_test.go
+++ b/pkg/clienttransport_test.go
@@ -68,7 +68,7 @@ func TestClientTransport(t *testing.T) {
 	cl := NewMockRoundTripper(ctrl)
 	reg := NewMockClientRegistry(ctrl)
 	loader := openapi3.NewSwaggerLoader()
-	spec, _ := loader.LoadSwaggerFromYAMLData([]byte(spectxt))
+	spec, _ := loader.LoadSwaggerFromData([]byte(spectxt))
 	router := openapi3filter.NewRouter()
 	assert.Nil(t, router.AddSwagger(spec))
 	rt := &ClientTransport{
@@ -93,7 +93,7 @@ func TestClientTransportNotFound(t *testing.T) {
 
 	reg := NewMockClientRegistry(ctrl)
 	loader := openapi3.NewSwaggerLoader()
-	spec, _ := loader.LoadSwaggerFromYAMLData([]byte(spectxt))
+	spec, _ := loader.LoadSwaggerFromData([]byte(spectxt))
 	router := openapi3filter.NewRouter()
 	assert.Nil(t, router.AddSwagger(spec))
 	rt := &ClientTransport{

--- a/pkg/components/validator_test.go
+++ b/pkg/components/validator_test.go
@@ -75,7 +75,7 @@ func TestValidateRequest(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	swagger, err := openapi3.NewSwaggerLoader().LoadSwaggerFromYAMLData([]byte(validatorYaml))
+	swagger, err := openapi3.NewSwaggerLoader().LoadSwaggerFromData([]byte(validatorYaml))
 	assert.Nil(t, err)
 	router := openapi3filter.NewRouter()
 	assert.Nil(t, router.AddSwagger(swagger))
@@ -101,7 +101,7 @@ func TestValidateRequestMissingParam(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	swagger, err := openapi3.NewSwaggerLoader().LoadSwaggerFromYAMLData([]byte(validatorYaml))
+	swagger, err := openapi3.NewSwaggerLoader().LoadSwaggerFromData([]byte(validatorYaml))
 	assert.Nil(t, err)
 	router := openapi3filter.NewRouter()
 	assert.Nil(t, router.AddSwagger(swagger))
@@ -124,7 +124,7 @@ func TestValidateResponse(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	swagger, err := openapi3.NewSwaggerLoader().LoadSwaggerFromYAMLData([]byte(validatorYaml))
+	swagger, err := openapi3.NewSwaggerLoader().LoadSwaggerFromData([]byte(validatorYaml))
 	assert.Nil(t, err)
 	router := openapi3filter.NewRouter()
 	assert.Nil(t, router.AddSwagger(swagger))
@@ -152,7 +152,7 @@ func TestValidateResponseMissingHeader(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	swagger, err := openapi3.NewSwaggerLoader().LoadSwaggerFromYAMLData([]byte(validatorYaml))
+	swagger, err := openapi3.NewSwaggerLoader().LoadSwaggerFromData([]byte(validatorYaml))
 	assert.Nil(t, err)
 	router := openapi3filter.NewRouter()
 	assert.Nil(t, router.AddSwagger(swagger))
@@ -180,7 +180,7 @@ func TestValidatorResponseBadShape(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	swagger, err := openapi3.NewSwaggerLoader().LoadSwaggerFromYAMLData([]byte(validatorYaml))
+	swagger, err := openapi3.NewSwaggerLoader().LoadSwaggerFromData([]byte(validatorYaml))
 	assert.Nil(t, err)
 	router := openapi3filter.NewRouter()
 	assert.Nil(t, router.AddSwagger(swagger))

--- a/pkg/new.go
+++ b/pkg/new.go
@@ -21,7 +21,7 @@ func New(ctx context.Context, specification []byte, components ...NewComponent) 
 	}
 
 	loader := openapi3.NewSwaggerLoader()
-	swagger, errYaml := loader.LoadSwaggerFromYAMLData(specification)
+	swagger, errYaml := loader.LoadSwaggerFromData(specification)
 	var errJSON error
 	if errYaml != nil {
 		swagger, errJSON = loader.LoadSwaggerFromData(specification)


### PR DESCRIPTION
kin-openapi stopped tagging their repo. We pulled in a fix that ben made which also brought in some backwards incompatible changes, namely: https://github.com/getkin/kin-openapi/pull/67