### PR TITLE
decode if data URI

### DIFF
--- a/pkg/components/asap.go
+++ b/pkg/components/asap.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	asap "bitbucket.org/atlassian/go-asap"
 	"github.com/SermoDigital/jose/crypto"
+	"github.com/vincent-petithory/dataurl"
 )
 
 type asapValidateTransport struct {
@@ -132,7 +134,12 @@ func (*ASAPTokenComponent) New(ctx context.Context, conf *ASAPTokenConfig) (func
 	if len(conf.KID) < 1 {
 		return nil, fmt.Errorf("kid value is empty")
 	}
-	privateKey, err := asap.NewPrivateKey([]byte(conf.PrivateKey))
+	rawKey := conf.PrivateKey
+	if strings.HasPrefix(rawKey, "data:") {
+		url, _ := dataurl.DecodeString(rawKey)
+		rawKey = string(url.Data)
+	}
+	privateKey, err := asap.NewPrivateKey([]byte(rawKey))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/components/asap_test.go
+++ b/pkg/components/asap_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/vincent-petithory/dataurl"
 )
 
 const (
@@ -167,6 +168,7 @@ func TestASAPTokenComponent_New(t *testing.T) {
 		Bytes: x509.MarshalPKCS1PrivateKey(pkBytes),
 	}
 	pk := pem.EncodeToMemory(pkBlock)
+	dataURIPK := dataurl.EncodeBytes(pk)
 	tests := []struct {
 		name    string
 		conf    *ASAPTokenConfig
@@ -216,6 +218,17 @@ func TestASAPTokenComponent_New(t *testing.T) {
 			name: "success",
 			conf: &ASAPTokenConfig{
 				PrivateKey: string(pk),
+				KID:        kid,
+				TTL:        tokenTTL,
+				Issuer:     iss,
+				Audiences:  []string{aud},
+			},
+			wantErr: false,
+		},
+		{
+			name: "success-data-uri",
+			conf: &ASAPTokenConfig{
+				PrivateKey: dataURIPK,
 				KID:        kid,
 				TTL:        tokenTTL,
 				Issuer:     iss,


### PR DESCRIPTION
Some environments may encode the private key as a data URI. This PR accounts for that.

I'm not sure if there is a better way to handle this.. open to feedback