### PR TITLE
Add ability to create a Transport from config

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -478,6 +478,7 @@
     "github.com/gobuffalo/packr/v2",
     "github.com/golang/mock/gomock",
     "github.com/stretchr/testify/assert",
+    "github.com/vincent-petithory/dataurl",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ from a container orchestration environment to one where running the proxy alongs
 the application is not possible. To help in these cases we offer the following:
 
 ```golang
-transport, err := transportd.New(ctx, fileContent, plugins...)
+transport, err := transportd.NewTransport(ctx, fileContent, plugins...)
 if err != nil {
   panic(err.Error())
 }

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
     - [Custom Plugins And Builds](#custom-plugins-and-builds)
         - [Writing A Component](#writing-a-component)
         - [Generating A Build](#generating-a-build)
+    - [Using As A Library](#using-as-a-library)
     - [Contributing](#contributing)
         - [License](#license)
         - [Contributing Agreement](#contributing-agreement)
@@ -436,6 +437,31 @@ func main() {
 	}
 }
 ```
+
+<a id="markdown-using-as-a-library" name="using-as-a-library"></a>
+## Using As A Library
+
+While the source projects like
+[transport](https://github.com/asecurityteam/transport) and
+[httpstats](https://github.com/asecurityteam/httpstats) can be used directly, there
+is a great deal of convenience in being able to configure all of the combined tooling
+through the OpenAPI extensions. This is particularly true if you are moving a system
+from a container orchestration environment to one where running the proxy alongside
+the application is not possible. To help in these cases we offer the following:
+
+```golang
+transport, err := transportd.New(ctx, fileContent, plugins...)
+if err != nil {
+  panic(err.Error())
+}
+client := &http.Client{
+  Transport: transport,
+}
+```
+
+The resulting `http.RoundTripper` implements all of the smart functionality of the
+reverse proxy but is exposed as a component that can be embedded in code and used
+anywhere an HTTP client would otherwise be used.
 
 <a id="markdown-contributing" name="contributing"></a>
 ## Contributing

--- a/pkg/new.go
+++ b/pkg/new.go
@@ -12,12 +12,13 @@ import (
 	"github.com/getkin/kin-openapi/openapi3filter"
 )
 
-// New generates a configured runtime.
-func New(ctx context.Context, specification []byte, components ...NewComponent) (*runhttp.Runtime, error) {
+// this method handles the fact that the runtime and the transport creation
+// both need the parsed openAPI spec but don't both need to parse it.
+func newTransport(ctx context.Context, specification []byte, components ...NewComponent) (http.RoundTripper, *openapi3.Swagger, error) {
 	envProcessor := NewEnvProcessor()
 	specification, err := envProcessor.Process(specification)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	loader := openapi3.NewSwaggerLoader()
@@ -27,27 +28,27 @@ func New(ctx context.Context, specification []byte, components ...NewComponent) 
 		swagger, errJSON = loader.LoadSwaggerFromData(specification)
 	}
 	if errYaml != nil && errJSON != nil {
-		return nil, errJSON
+		return nil, nil, errJSON
 	}
 	router := openapi3filter.NewRouter()
 	err = router.AddSwagger(swagger)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Load and configure available backends.
 	var rawBackendConf interface{}
 	var ok bool
 	if rawBackendConf, ok = swagger.Extensions[ExtensionKey]; !ok {
-		return nil, fmt.Errorf("missing backend configuration")
+		return nil, nil, fmt.Errorf("missing backend configuration")
 	}
 	s, err := SourceFromExtension([]byte(rawBackendConf.(json.RawMessage)))
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse backend configuration: %s", err.Error())
+		return nil, nil, fmt.Errorf("failed to parse backend configuration: %s", err.Error())
 	}
 	transports, err := NewBaseTransports(ctx, s)
 	if err != nil {
-		return nil, fmt.Errorf("failed to configure backends: %s", err.Error())
+		return nil, nil, fmt.Errorf("failed to configure backends: %s", err.Error())
 	}
 
 	// Load and configure endpoints.
@@ -59,26 +60,42 @@ func New(ctx context.Context, specification []byte, components ...NewComponent) 
 	for path, pathItem := range swagger.Paths {
 		for method, op := range pathItem.Operations() {
 			if _, ok = op.Extensions[ExtensionKey]; !ok {
-				return nil, fmt.Errorf("missing client configuration for %s.%s", path, method)
+				return nil, nil, fmt.Errorf("missing client configuration for %s.%s", path, method)
 			}
 			opS, opErr := SourceFromExtension([]byte(op.Extensions[ExtensionKey].(json.RawMessage)))
 			if opErr != nil {
-				return nil, fmt.Errorf("failed to parse client configuration for %s.%s: %s", path, method, opErr.Error())
+				return nil, nil, fmt.Errorf("failed to parse client configuration for %s.%s: %s", path, method, opErr.Error())
 			}
 			client, opErr := clientF.New(ctx, opS, path, method)
 			if opErr != nil {
-				return nil, fmt.Errorf("failed client configuration for %s.%s: %s", path, method, opErr.Error())
+				return nil, nil, fmt.Errorf("failed client configuration for %s.%s: %s", path, method, opErr.Error())
 			}
 			reg.Store(ctx, path, method, client)
 		}
 	}
+	return &ClientTransport{
+		Router:   router,
+		Registry: reg,
+	}, swagger, nil
+}
 
+// NewTransport constructs a smart HTTP client from the given specification
+// and set of plugins. For running a service, use the New method instead.
+func NewTransport(ctx context.Context, specification []byte, components ...NewComponent) (http.RoundTripper, error) {
+	transport, _, err := newTransport(ctx, specification, components...)
+	return transport, err
+}
+
+// New generates a configured HTTP runtime. To use as a library, call the
+// NewTransport method instead.
+func New(ctx context.Context, specification []byte, components ...NewComponent) (*runhttp.Runtime, error) {
+	transport, swagger, err := newTransport(ctx, specification, components...)
+	if err != nil {
+		return nil, err
+	}
 	handler := &httputil.ReverseProxy{
-		Director: func(*http.Request) {},
-		Transport: &ClientTransport{
-			Router:   router,
-			Registry: reg,
-		},
+		Director:  func(*http.Request) {},
+		Transport: transport,
 		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
 			runhttp.LoggerFromContext(r.Context()).Error(struct {
 				Message string `logevent:"message,default=uncaught-exception"`
@@ -99,10 +116,11 @@ func New(ctx context.Context, specification []byte, components ...NewComponent) 
 
 	// Load and configure the runtime settings.
 	var rawRuntimeConf interface{}
+	var ok bool
 	if rawRuntimeConf, ok = swagger.Extensions[RuntimeExtensionKey]; !ok {
 		return nil, fmt.Errorf("missing x-runtime configuration")
 	}
-	s, err = RuntimeSourceFromExtension([]byte(rawRuntimeConf.(json.RawMessage)))
+	s, err := RuntimeSourceFromExtension([]byte(rawRuntimeConf.(json.RawMessage)))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse runtime configuration: %s", err.Error())
 	}

--- a/pkg/new.go
+++ b/pkg/new.go
@@ -12,43 +12,45 @@ import (
 	"github.com/getkin/kin-openapi/openapi3filter"
 )
 
-// this method handles the fact that the runtime and the transport creation
-// both need the parsed openAPI spec but don't both need to parse it.
-func newTransport(ctx context.Context, specification []byte, components ...NewComponent) (http.RoundTripper, *openapi3.Swagger, error) {
+func newSpecification(source []byte) (*openapi3.Swagger, error) {
 	envProcessor := NewEnvProcessor()
-	specification, err := envProcessor.Process(specification)
+	source, err := envProcessor.Process(source)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	loader := openapi3.NewSwaggerLoader()
-	swagger, errYaml := loader.LoadSwaggerFromData(specification)
+	swagger, errYaml := loader.LoadSwaggerFromData(source)
 	var errJSON error
 	if errYaml != nil {
-		swagger, errJSON = loader.LoadSwaggerFromData(specification)
+		swagger, errJSON = loader.LoadSwaggerFromData(source)
 	}
 	if errYaml != nil && errJSON != nil {
-		return nil, nil, errJSON
+		return nil, errJSON
 	}
+	return swagger, nil
+}
+
+func newTransport(ctx context.Context, specification *openapi3.Swagger, components ...NewComponent) (http.RoundTripper, error) {
 	router := openapi3filter.NewRouter()
-	err = router.AddSwagger(swagger)
+	err := router.AddSwagger(specification)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	// Load and configure available backends.
 	var rawBackendConf interface{}
 	var ok bool
-	if rawBackendConf, ok = swagger.Extensions[ExtensionKey]; !ok {
-		return nil, nil, fmt.Errorf("missing backend configuration")
+	if rawBackendConf, ok = specification.Extensions[ExtensionKey]; !ok {
+		return nil, fmt.Errorf("missing backend configuration")
 	}
 	s, err := SourceFromExtension([]byte(rawBackendConf.(json.RawMessage)))
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to parse backend configuration: %s", err.Error())
+		return nil, fmt.Errorf("failed to parse backend configuration: %s", err.Error())
 	}
 	transports, err := NewBaseTransports(ctx, s)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to configure backends: %s", err.Error())
+		return nil, fmt.Errorf("failed to configure backends: %s", err.Error())
 	}
 
 	// Load and configure endpoints.
@@ -57,18 +59,18 @@ func newTransport(ctx context.Context, specification []byte, components ...NewCo
 		Bases:      transports,
 		Components: components,
 	}
-	for path, pathItem := range swagger.Paths {
+	for path, pathItem := range specification.Paths {
 		for method, op := range pathItem.Operations() {
 			if _, ok = op.Extensions[ExtensionKey]; !ok {
-				return nil, nil, fmt.Errorf("missing client configuration for %s.%s", path, method)
+				return nil, fmt.Errorf("missing client configuration for %s.%s", path, method)
 			}
 			opS, opErr := SourceFromExtension([]byte(op.Extensions[ExtensionKey].(json.RawMessage)))
 			if opErr != nil {
-				return nil, nil, fmt.Errorf("failed to parse client configuration for %s.%s: %s", path, method, opErr.Error())
+				return nil, fmt.Errorf("failed to parse client configuration for %s.%s: %s", path, method, opErr.Error())
 			}
 			client, opErr := clientF.New(ctx, opS, path, method)
 			if opErr != nil {
-				return nil, nil, fmt.Errorf("failed client configuration for %s.%s: %s", path, method, opErr.Error())
+				return nil, fmt.Errorf("failed client configuration for %s.%s: %s", path, method, opErr.Error())
 			}
 			reg.Store(ctx, path, method, client)
 		}
@@ -76,20 +78,28 @@ func newTransport(ctx context.Context, specification []byte, components ...NewCo
 	return &ClientTransport{
 		Router:   router,
 		Registry: reg,
-	}, swagger, nil
+	}, nil
 }
 
 // NewTransport constructs a smart HTTP client from the given specification
 // and set of plugins. For running a service, use the New method instead.
 func NewTransport(ctx context.Context, specification []byte, components ...NewComponent) (http.RoundTripper, error) {
-	transport, _, err := newTransport(ctx, specification, components...)
+	spec, err := newSpecification(specification)
+	if err != nil {
+		return nil, err
+	}
+	transport, err := newTransport(ctx, spec, components...)
 	return transport, err
 }
 
 // New generates a configured HTTP runtime. To use as a library, call the
 // NewTransport method instead.
 func New(ctx context.Context, specification []byte, components ...NewComponent) (*runhttp.Runtime, error) {
-	transport, swagger, err := newTransport(ctx, specification, components...)
+	spec, err := newSpecification(specification)
+	if err != nil {
+		return nil, err
+	}
+	transport, err := newTransport(ctx, spec, components...)
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +127,7 @@ func New(ctx context.Context, specification []byte, components ...NewComponent) 
 	// Load and configure the runtime settings.
 	var rawRuntimeConf interface{}
 	var ok bool
-	if rawRuntimeConf, ok = swagger.Extensions[RuntimeExtensionKey]; !ok {
+	if rawRuntimeConf, ok = spec.Extensions[RuntimeExtensionKey]; !ok {
 		return nil, fmt.Errorf("missing x-runtime configuration")
 	}
 	s, err := RuntimeSourceFromExtension([]byte(rawRuntimeConf.(json.RawMessage)))


### PR DESCRIPTION
This change will facilitate embedding a smart client (equivalent to the
proxy) into systems where we have no control over container
provisioning. For example, this will enable users to migrate from EC2 to
Lambda without losing the features provided by a transportd side-car.