### PR TITLE
Add header injection for requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ x-transportd:
     - "requestvalidation"
     - "responsevalidation"
     - "strip"
+    - "headerinject"
   # (string) Backend target for this route.
   backend: "backendName"
   metrics:
@@ -229,6 +230,11 @@ x-transportd:
   strip:
     # (int) Number of URL segments to remove from the beginning of the path before redirect.
     count: 0
+  headerinject:
+    # ([]string) List of header names to inject.
+    names:
+    # ([]string) List of header values to inject.
+    values:
 ```
 
 <a id="markdown-environment-variables" name="environment-variables"></a>

--- a/pkg/components/defaults.go
+++ b/pkg/components/defaults.go
@@ -19,5 +19,6 @@ var (
 		RequestValidation,
 		ResponseValidation,
 		Strip,
+		Header,
 	}
 )

--- a/pkg/components/header.go
+++ b/pkg/components/header.go
@@ -1,0 +1,55 @@
+package components
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/asecurityteam/transport"
+)
+
+// HeaderConfig configures automated header injection.
+type HeaderConfig struct {
+	Names  []string `description:"List of header names to inject."`
+	Values []string `description:"List of header values to inject."`
+}
+
+// Name of the config root.
+func (*HeaderConfig) Name() string {
+	return "headerinject"
+}
+
+// HeaderComponent implements the settings.Component interface.
+type HeaderComponent struct{}
+
+// Header satisfies the NewComponent signature.
+func Header(_ context.Context, _ string, _ string, _ string) (interface{}, error) {
+	return &HeaderComponent{}, nil
+}
+
+// Settings generates a config populated with defaults.
+func (*HeaderComponent) Settings() *HeaderConfig {
+	return &HeaderConfig{Names: []string{}, Values: []string{}}
+}
+
+func makeDecorator(name string, value string) transport.Decorator {
+	return transport.NewHeader(func(*http.Request) (string, string) {
+		return name, value
+	})
+}
+
+// New generates the middleware.
+func (*HeaderComponent) New(_ context.Context, conf *HeaderConfig) (func(http.RoundTripper) http.RoundTripper, error) { // nolint
+	if len(conf.Names) != len(conf.Values) {
+		return nil, fmt.Errorf(
+			"header mismatch. %d names. %d values. these must match",
+			len(conf.Names),
+			len(conf.Values),
+		)
+	}
+	ch := make(transport.Chain, 0, len(conf.Names))
+	for offset, name := range conf.Names {
+		ch = append(ch, makeDecorator(name, conf.Values[offset]))
+	}
+	return ch.Apply, nil
+}

--- a/pkg/components/header_test.go
+++ b/pkg/components/header_test.go
@@ -1,0 +1,44 @@
+package components
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHeaderInjectionConfigError(t *testing.T) {
+	cmp := &HeaderComponent{}
+	set := cmp.Settings()
+	set.Names = []string{"one", "two"}
+	set.Values = []string{"one"}
+	_, err := cmp.New(context.Background(), set)
+	assert.Error(t, err)
+}
+
+func TestHeaderInjection(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	rt := NewMockRoundTripper(ctrl)
+	cmp := &HeaderComponent{}
+	set := cmp.Settings()
+	set.Names = []string{"one", "two", "three"}
+	set.Values = []string{"a", "b", "c"}
+	d, err := cmp.New(context.Background(), set)
+	assert.NoError(t, err)
+
+	req, _ := http.NewRequest(http.MethodGet, "http://localhost", http.NoBody)
+	wrapped := d(rt)
+
+	rt.EXPECT().RoundTrip(gomock.Any()).Do(func(r *http.Request) {
+		assert.Equal(t, "a", r.Header.Get("one"))
+		assert.Equal(t, "b", r.Header.Get("two"))
+		assert.Equal(t, "c", r.Header.Get("three"))
+	})
+	_, err = wrapped.RoundTrip(req)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
This enables proxy users to inject values such as authentication tokens
as a header in a request.