### PR TITLE
Add an HTTP basic auth component to plugin set

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ x-transportd:
     - "responsevalidation"
     - "strip"
     - "headerinject"
+    - "basicauth"
   # (string) Backend target for this route.
   backend: "backendName"
   metrics:
@@ -236,6 +237,11 @@ x-transportd:
     names:
     # ([]string) List of header values to inject.
     values:
+  basicauth:
+    # (string) Username to use in HTTP basic authentication.
+    username: ""
+    # (string) Password to use in HTTP basic authentication.
+    password: ""
 ```
 
 <a id="markdown-environment-variables" name="environment-variables"></a>

--- a/pkg/components/basicauth.go
+++ b/pkg/components/basicauth.go
@@ -1,0 +1,60 @@
+package components
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+type basicAuthTransport struct {
+	Username string
+	Password string
+	Wrapped  http.RoundTripper
+}
+
+func (c *basicAuthTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	r.SetBasicAuth(c.Username, c.Password)
+	return c.Wrapped.RoundTrip(r)
+}
+
+// BasicAuthConfig is used to configure HTTP basic authentication.
+type BasicAuthConfig struct {
+	Username string `description:"Username to use in HTTP basic authentication."`
+	Password string `description:"Password to use in HTTP basic authentication."`
+}
+
+// Name of the config root.
+func (c *BasicAuthConfig) Name() string {
+	return "basicauth"
+}
+
+// BasicAuthComponent is an HTTP basic auth decorator plugin.
+type BasicAuthComponent struct{}
+
+// BasicAuth satisfies the NewComponent signature.
+func BasicAuth(_ context.Context, _ string, _ string, _ string) (interface{}, error) {
+	return &BasicAuthComponent{}, nil
+}
+
+// Settings generates a config populated with defaults.
+func (m *BasicAuthComponent) Settings() *BasicAuthConfig {
+	return &BasicAuthConfig{}
+}
+
+// New generates the middleware.
+func (*BasicAuthComponent) New(ctx context.Context, conf *BasicAuthConfig) (func(http.RoundTripper) http.RoundTripper, error) {
+	if len(conf.Username) < 1 {
+		return nil, fmt.Errorf("username value is empty")
+	}
+	if len(conf.Password) < 1 {
+		return nil, fmt.Errorf("password value is empty")
+	}
+
+	return func(next http.RoundTripper) http.RoundTripper {
+		return &basicAuthTransport{
+			Username: conf.Username,
+			Password: conf.Password,
+			Wrapped:  next,
+		}
+	}, nil
+}

--- a/pkg/components/basicauth_test.go
+++ b/pkg/components/basicauth_test.go
@@ -1,0 +1,79 @@
+package components
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+)
+
+func TestBasicAuthComponent_New(t *testing.T) {
+	user := "user"
+	pass := "pass"
+	tests := []struct {
+		name    string
+		conf    *BasicAuthConfig
+		wantErr bool
+	}{
+		{
+			name: "missing or empty username",
+			conf: &BasicAuthConfig{
+				Password: pass,
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing or empty password",
+			conf: &BasicAuthConfig{
+				Username: user,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &BasicAuthComponent{}
+			_, err := b.New(context.Background(), tt.conf)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("BasicAuthComponent.New() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}
+
+func TestBasicAuthTransport_RoundTrip(t *testing.T) {
+	user := "user"
+	pass := "pass"
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	rt := NewMockRoundTripper(ctrl)
+	c := &basicAuthTransport{
+		Wrapped:  rt,
+		Username: user,
+		Password: pass,
+	}
+
+	r := &http.Request{Header: http.Header{}}
+	rt.EXPECT().RoundTrip(gomock.Any()).Return(
+		&http.Response{
+			Status:     "200 OK",
+			StatusCode: http.StatusOK,
+			Body:       http.NoBody,
+		},
+		nil,
+	)
+
+	_, _ = c.RoundTrip(r)
+	u, p, ok := r.BasicAuth()
+	if !ok {
+		t.Errorf("basicAuthTransport.RoundTrip() did not set basic auth headers")
+		return
+	}
+	if user != u || pass != p {
+		t.Errorf("basicAuthTransport.RoundTrip() user = %s pass = %s, want %s %s", user, pass, u, p)
+	}
+}

--- a/pkg/components/defaults.go
+++ b/pkg/components/defaults.go
@@ -20,5 +20,6 @@ var (
 		ResponseValidation,
 		Strip,
 		Header,
+		BasicAuth,
 	}
 )

--- a/tests/specs/complete.yaml
+++ b/tests/specs/complete.yaml
@@ -72,6 +72,7 @@ paths:
           - "requestvalidation"
           - "responsevalidation"
           - "strip"
+          - "basicauth"
         backend: "app"
         timeout:
           after: "175ms"
@@ -95,3 +96,6 @@ paths:
             - 511
         strip:
           count: 0
+        basicauth:
+          username: "user"
+          password: "password"


### PR DESCRIPTION
Provides a basicauth component for configuring injecting basic auth into an HTTP request proxied through transportd and adds it to the default components.