### PR TITLE
Fix race condition in timeout component

### DIFF
--- a/pkg/components/timeout_test.go
+++ b/pkg/components/timeout_test.go
@@ -1,0 +1,34 @@
+package components
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTimeoutContext(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	wrapped := NewMockRoundTripper(ctrl)
+	rt := &timeoutRoundTripper{
+		RoundTripper: wrapped,
+		after:        time.Hour,
+	}
+	req, _ := http.NewRequest(http.MethodGet, "http://localhost", http.NoBody)
+	var capturedCtx context.Context
+
+	wrapped.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
+		func(r *http.Request) (*http.Response, error) {
+			capturedCtx = r.Context()
+			return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+		},
+	)
+	_, _ = rt.RoundTrip(req)
+	assert.NotNil(t, capturedCtx)
+	assert.Nil(t, capturedCtx.Err())
+}


### PR DESCRIPTION
Canceling the context with a defer inside the middleware results in the
underlying network connection being closed shortly after. This is a
problem if the proxy is unable to copy all of the response data back to
the caller before the connection is closed.