### PR TITLE
SECD-638 Handle compressed response bodies in response validation

### DIFF
--- a/pkg/components/validate.go
+++ b/pkg/components/validate.go
@@ -2,7 +2,9 @@ package components
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
+	"io"
 	"io/ioutil"
 	"net/http"
 
@@ -66,16 +68,17 @@ type outputValidatingTransport struct {
 func (r *outputValidatingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	originalPath := req.URL.Path
 	resp, err := r.Wrapped.RoundTrip(req)
-	// restore the old path just in case something else modified it from the path in the specification
-	req.URL.Path = originalPath
 	if err != nil {
 		return nil, err
 	}
+	// restore the old path just in case something else modified it from the path in the specification
+	req.URL.Path = originalPath
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
 	resp.Body = ioutil.NopCloser(bytes.NewReader(body))
+
 	route := transportd.RouteFromContext(req.Context())
 	params := transportd.PathParamsFromContext(req.Context())
 	reqInput := &openapi3filter.RequestValidationInput{
@@ -84,11 +87,25 @@ func (r *outputValidatingTransport) RoundTrip(req *http.Request) (*http.Response
 		QueryParams: req.URL.Query(),
 		PathParams:  params,
 	}
+
+	// response validation will fail if the response body is compressed,
+	// so we ensure the payload is uncompressed
+	var reader io.ReadCloser
+	switch resp.Header.Get("Content-Encoding") {
+	case "gzip":
+		reader, err = gzip.NewReader(bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		defer reader.Close()
+	default:
+		reader = ioutil.NopCloser(bytes.NewReader(body))
+	}
 	input := &openapi3filter.ResponseValidationInput{
 		RequestValidationInput: reqInput,
 		Status:                 resp.StatusCode,
 		Header:                 resp.Header,
-		Body:                   ioutil.NopCloser(bytes.NewReader(body)),
+		Body:                   reader,
 	}
 	err = openapi3filter.ValidateResponse(req.Context(), input)
 	if err != nil {

--- a/pkg/components/validator_test.go
+++ b/pkg/components/validator_test.go
@@ -3,6 +3,7 @@ package components
 import (
 	"bytes"
 	"compress/gzip"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"testing"
@@ -73,6 +74,32 @@ components:
 )
 
 func TestValidateRequest(t *testing.T) {
+	tests := []struct {
+		name        string
+		url         string
+		response    *http.Response
+		responseErr error
+		statusCode  int
+	}{
+		{
+			name: "valid request",
+			url:  "https://localhost/hello?name=test1&name2=test2",
+			response: &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       http.NoBody,
+			},
+			responseErr: nil,
+			statusCode:  http.StatusOK,
+		},
+		{
+			name:        "missing param",
+			url:         "https://localhost/hello?name=test1",
+			response:    nil,
+			responseErr: nil,
+			statusCode:  http.StatusBadRequest,
+		},
+	}
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -81,166 +108,144 @@ func TestValidateRequest(t *testing.T) {
 	router := openapi3filter.NewRouter()
 	assert.Nil(t, router.AddSwagger(swagger))
 
-	rt := NewMockRoundTripper(ctrl)
-	c := &inputValidatingTransport{Wrapped: rt}
-	req, _ := http.NewRequest(http.MethodGet, "https://localhost/hello?name=test1&name2=test2", http.NoBody)
+	for _, tt := range tests {
+		rt := NewMockRoundTripper(ctrl)
+		c := &inputValidatingTransport{Wrapped: rt}
+		req, _ := http.NewRequest(http.MethodGet, tt.url, http.NoBody)
 
-	route, pathParams, err := router.FindRoute(req.Method, req.URL)
-	assert.Nil(t, err)
-	req = req.WithContext(transportd.RouteToContext(req.Context(), route))
-	req = req.WithContext(transportd.PathParamsToContext(req.Context(), pathParams))
+		route, pathParams, err := router.FindRoute(req.Method, req.URL)
+		assert.Nil(t, err)
+		req = req.WithContext(transportd.RouteToContext(req.Context(), route))
+		req = req.WithContext(transportd.PathParamsToContext(req.Context(), pathParams))
 
-	rt.EXPECT().RoundTrip(gomock.Any()).Return(&http.Response{
-		StatusCode: http.StatusOK,
-		Body:       http.NoBody,
-	}, nil)
-	_, err = c.RoundTrip(req)
-	assert.Nil(t, err)
-}
-
-func TestValidateRequestMissingParam(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	swagger, err := openapi3.NewSwaggerLoader().LoadSwaggerFromData([]byte(validatorYaml))
-	assert.Nil(t, err)
-	router := openapi3filter.NewRouter()
-	assert.Nil(t, router.AddSwagger(swagger))
-
-	rt := NewMockRoundTripper(ctrl)
-	c := &inputValidatingTransport{Wrapped: rt}
-	req, _ := http.NewRequest(http.MethodGet, "https://localhost/hello?name=test1", http.NoBody)
-
-	route, pathParams, err := router.FindRoute(req.Method, req.URL)
-	assert.Nil(t, err)
-	req = req.WithContext(transportd.RouteToContext(req.Context(), route))
-	req = req.WithContext(transportd.PathParamsToContext(req.Context(), pathParams))
-
-	resp, err := c.RoundTrip(req)
-	assert.Nil(t, err)
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		if tt.response != nil {
+			rt.EXPECT().RoundTrip(gomock.Any()).Return(tt.response, tt.responseErr)
+		}
+		resp, err := c.RoundTrip(req)
+		assert.Nil(t, err)
+		assert.Equal(t, tt.statusCode, resp.StatusCode)
+	}
 }
 
 func TestValidateResponse(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	swagger, err := openapi3.NewSwaggerLoader().LoadSwaggerFromData([]byte(validatorYaml))
-	assert.Nil(t, err)
-	router := openapi3filter.NewRouter()
-	assert.Nil(t, router.AddSwagger(swagger))
-
-	rt := NewMockRoundTripper(ctrl)
-	c := &outputValidatingTransport{Wrapped: rt}
-	req, _ := http.NewRequest(http.MethodGet, "https://localhost/hello?name=test1&name2=test2", http.NoBody)
-
-	route, pathParams, err := router.FindRoute(req.Method, req.URL)
-	assert.Nil(t, err)
-	req = req.WithContext(transportd.RouteToContext(req.Context(), route))
-	req = req.WithContext(transportd.PathParamsToContext(req.Context(), pathParams))
-
-	rt.EXPECT().RoundTrip(gomock.Any()).Return(&http.Response{
-		StatusCode: http.StatusOK,
-		Status:     "200 OK",
-		Header:     http.Header{"Content-Type": []string{"application/json"}},
-		Body:       ioutil.NopCloser(bytes.NewBufferString(`{"greeting": "hello"}`)),
-	}, nil)
-	resp, err := c.RoundTrip(req)
-	assert.Nil(t, err)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-}
-
-func TestValidateResponseMissingHeader(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	swagger, err := openapi3.NewSwaggerLoader().LoadSwaggerFromData([]byte(validatorYaml))
-	assert.Nil(t, err)
-	router := openapi3filter.NewRouter()
-	assert.Nil(t, router.AddSwagger(swagger))
-
-	rt := NewMockRoundTripper(ctrl)
-	c := &outputValidatingTransport{Wrapped: rt}
-	req, _ := http.NewRequest(http.MethodGet, "https://localhost/hello?name=test1&name2=test2", http.NoBody)
-
-	route, pathParams, err := router.FindRoute(req.Method, req.URL)
-	assert.Nil(t, err)
-	req = req.WithContext(transportd.RouteToContext(req.Context(), route))
-	req = req.WithContext(transportd.PathParamsToContext(req.Context(), pathParams))
-
-	rt.EXPECT().RoundTrip(gomock.Any()).Return(&http.Response{
-		StatusCode: http.StatusOK,
-		Status:     "200 OK",
-		Body:       ioutil.NopCloser(bytes.NewBufferString(`{"greeting": "hello"}`)),
-	}, nil)
-	resp, err := c.RoundTrip(req)
-	assert.Nil(t, err)
-	assert.Equal(t, http.StatusBadGateway, resp.StatusCode)
-}
-
-func TestValidatorResponseBadShape(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	swagger, err := openapi3.NewSwaggerLoader().LoadSwaggerFromData([]byte(validatorYaml))
-	assert.Nil(t, err)
-	router := openapi3filter.NewRouter()
-	assert.Nil(t, router.AddSwagger(swagger))
-
-	rt := NewMockRoundTripper(ctrl)
-	c := &outputValidatingTransport{Wrapped: rt}
-	req, _ := http.NewRequest(http.MethodGet, "https://localhost/hello?name=test1&name2=test2", http.NoBody)
-
-	route, pathParams, err := router.FindRoute(req.Method, req.URL)
-	assert.Nil(t, err)
-	req = req.WithContext(transportd.RouteToContext(req.Context(), route))
-	req = req.WithContext(transportd.PathParamsToContext(req.Context(), pathParams))
-
-	rt.EXPECT().RoundTrip(gomock.Any()).Return(&http.Response{
-		StatusCode: http.StatusOK,
-		Status:     "200 OK",
-		Header:     http.Header{"Content-Type": []string{"application/json"}},
-		Body:       ioutil.NopCloser(bytes.NewBufferString(`{"notagreeting": "hello"}`)),
-	}, nil)
-	resp, err := c.RoundTrip(req)
-	assert.Nil(t, err)
-	assert.Equal(t, http.StatusBadGateway, resp.StatusCode)
-}
-
-func TestValidateCompressedResponse(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	swagger, err := openapi3.NewSwaggerLoader().LoadSwaggerFromData([]byte(validatorYaml))
-	assert.Nil(t, err)
-	router := openapi3filter.NewRouter()
-	assert.Nil(t, router.AddSwagger(swagger))
-
-	rt := NewMockRoundTripper(ctrl)
-	c := &outputValidatingTransport{Wrapped: rt}
-	req, _ := http.NewRequest(http.MethodGet, "https://localhost/hello?name=test1&name2=test2", http.NoBody)
-	req.Header.Set("Accept-Encoding", "gzip")
-	route, pathParams, err := router.FindRoute(req.Method, req.URL)
-	assert.Nil(t, err)
-	req = req.WithContext(transportd.RouteToContext(req.Context(), route))
-	req = req.WithContext(transportd.PathParamsToContext(req.Context(), pathParams))
-
+	body := `{"greeting": "hello"}`
 	var buf bytes.Buffer
 	zw := gzip.NewWriter(&buf)
-	_, err = zw.Write([]byte(`{"greeting": "hello"}`))
+	_, err := zw.Write([]byte(body))
 	assert.Nil(t, err)
 	assert.Nil(t, zw.Close())
-
-	rt.EXPECT().RoundTrip(gomock.Any()).Return(&http.Response{
-		StatusCode: http.StatusOK,
-		Status:     "200 OK",
-		Header: http.Header{
-			"Content-Type":     []string{"application/json"},
-			"Content-Encoding": []string{"gzip"},
-		},
-		Body: ioutil.NopCloser(&buf),
-	}, nil)
-	resp, err := c.RoundTrip(req)
+	compressedBody, err := ioutil.ReadAll(&buf)
 	assert.Nil(t, err)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	tests := []struct {
+		name        string
+		response    *http.Response
+		responseErr error
+		expectedErr bool
+		statusCode  int
+	}{
+		{
+			name: "valid response",
+			response: &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       ioutil.NopCloser(bytes.NewBufferString(body)),
+			},
+			responseErr: nil,
+			expectedErr: false,
+			statusCode:  http.StatusOK,
+		},
+		{
+			name: "missing header",
+			response: &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Body:       ioutil.NopCloser(bytes.NewBufferString(body)),
+			},
+			responseErr: nil,
+			expectedErr: false,
+			statusCode:  http.StatusBadGateway,
+		},
+		{
+			name: "compressed response",
+			response: &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Header: http.Header{
+					"Content-Type":     []string{"application/json"},
+					"Content-Encoding": []string{"gzip"},
+				},
+				Body: ioutil.NopCloser(bytes.NewReader(compressedBody)),
+			},
+			responseErr: nil,
+			expectedErr: false,
+			statusCode:  http.StatusOK,
+		},
+		{
+			name: "compressed response missing header",
+			response: &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Header: http.Header{
+					"Content-Type": []string{"application/json"},
+				},
+				Body: ioutil.NopCloser(bytes.NewReader(compressedBody)),
+			},
+			responseErr: nil,
+			expectedErr: false,
+			statusCode:  http.StatusBadGateway,
+		},
+		{
+			name: "compressed header with uncompressed body",
+			response: &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Header: http.Header{
+					"Content-Type":     []string{"application/json"},
+					"Content-Encoding": []string{"gzip"},
+				},
+				Body: ioutil.NopCloser(bytes.NewBufferString(body)),
+			},
+			responseErr: nil,
+			expectedErr: true,
+			statusCode:  -1,
+		},
+		{
+			name:        "response error",
+			response:    nil,
+			responseErr: fmt.Errorf("response error"),
+			expectedErr: true,
+			statusCode:  -1,
+		},
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	swagger, err := openapi3.NewSwaggerLoader().LoadSwaggerFromData([]byte(validatorYaml))
+	assert.Nil(t, err)
+	router := openapi3filter.NewRouter()
+	assert.Nil(t, router.AddSwagger(swagger))
+
+	for _, tt := range tests {
+		rt := NewMockRoundTripper(ctrl)
+		c := &outputValidatingTransport{Wrapped: rt}
+		req, _ := http.NewRequest(http.MethodGet, "https://localhost/hello?name=test1&name2=test2", http.NoBody)
+		req.Header.Set("Accept-Encoding", "gzip")
+		route, pathParams, err := router.FindRoute(req.Method, req.URL)
+		assert.Nil(t, err)
+		req = req.WithContext(transportd.RouteToContext(req.Context(), route))
+		req = req.WithContext(transportd.PathParamsToContext(req.Context(), pathParams))
+
+		rt.EXPECT().RoundTrip(gomock.Any()).Return(tt.response, tt.responseErr)
+		resp, err := c.RoundTrip(req)
+		if tt.expectedErr {
+			assert.NotNil(t, err)
+			assert.Nil(t, resp)
+			return
+		}
+		assert.Nil(t, err)
+		assert.Equal(t, tt.statusCode, resp.StatusCode)
+	}
 }


### PR DESCRIPTION
 The github.com/getkin/kin-openapi/openapi3filter will fail to decode the JSON response body if it is compressed. This adds support for ensuring the response body is uncompressed before invoking the openapi3filter library for response validation.

Reworks validate tests as table tests due to linting complaining about reuse.