### PR TITLE
Add handling of redirects

### DIFF
--- a/pkg/modifyresponse.go
+++ b/pkg/modifyresponse.go
@@ -1,0 +1,41 @@
+package transportd
+
+import (
+	"net/http"
+	"net/url"
+)
+
+// MultiResponseModifier enables composition of ModifyResponse functions.
+type MultiResponseModifier []func(*http.Response) error
+
+// ModifyResponse satisfies the signature of the same name in the ReverseProxy.
+func (mrs MultiResponseModifier) ModifyResponse(resp *http.Response) error {
+	for _, mr := range mrs {
+		if err := mr(resp); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// EnforceRelativeLocation prevents redirection from the backend as the result
+// of 3xx codes from improperly redirecting clients around the proxy. This is
+// related to https://github.com/golang/go/issues/14237.
+func EnforceRelativeLocation(resp *http.Response) error {
+	loc := resp.Header.Get("Location")
+	if loc == "" {
+		return nil
+	}
+	u, err := url.Parse(loc)
+	if err != nil {
+		// If Location isn't a valid URL then we skip the logic as it isn't
+		// needed.
+		return nil
+	}
+	// Removing the host and scheme results in /path/to/api?queries=here
+	// rather than the original https://hostname.com/path/to/api?queries=here.
+	u.Host = ""
+	u.Scheme = ""
+	resp.Header.Set("Location", u.String())
+	return nil
+}

--- a/pkg/modifyresponse_test.go
+++ b/pkg/modifyresponse_test.go
@@ -62,7 +62,7 @@ func TestEnforceRelativeLocation(t *testing.T) {
 			wantLocation: "/path/to/api?q=1",
 		},
 		{
-			name: "relative location (trailing)",
+			name: "absolute location (trailing)",
 			resp: &http.Response{
 				Header: http.Header{
 					"Location": []string{"https://localhost/path/to/api/?q=1"},

--- a/pkg/modifyresponse_test.go
+++ b/pkg/modifyresponse_test.go
@@ -1,0 +1,134 @@
+package transportd
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+func TestEnforceRelativeLocation(t *testing.T) {
+	tests := []struct {
+		name         string
+		resp         *http.Response
+		wantErr      bool
+		wantLocation string
+	}{
+		{
+			name: "missing location",
+			resp: &http.Response{
+				Header: http.Header{},
+			},
+			wantErr:      false,
+			wantLocation: "",
+		},
+		{
+			name: "invalid location",
+			resp: &http.Response{
+				Header: http.Header{
+					"Location": []string{"https://[XXX]:notport/path"},
+				},
+			},
+			wantErr:      false,
+			wantLocation: "https://[XXX]:notport/path",
+		},
+		{
+			name: "relative location",
+			resp: &http.Response{
+				Header: http.Header{
+					"Location": []string{"/path/to/api?q=1"},
+				},
+			},
+			wantErr:      false,
+			wantLocation: "/path/to/api?q=1",
+		},
+		{
+			name: "relative location (trailing)",
+			resp: &http.Response{
+				Header: http.Header{
+					"Location": []string{"/path/to/api/?q=1"},
+				},
+			},
+			wantErr:      false,
+			wantLocation: "/path/to/api/?q=1",
+		},
+		{
+			name: "absolute location",
+			resp: &http.Response{
+				Header: http.Header{
+					"Location": []string{"https://localhost/path/to/api?q=1"},
+				},
+			},
+			wantErr:      false,
+			wantLocation: "/path/to/api?q=1",
+		},
+		{
+			name: "relative location (trailing)",
+			resp: &http.Response{
+				Header: http.Header{
+					"Location": []string{"https://localhost/path/to/api/?q=1"},
+				},
+			},
+			wantErr:      false,
+			wantLocation: "/path/to/api/?q=1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := EnforceRelativeLocation(tt.resp); (err != nil) != tt.wantErr {
+				t.Errorf("EnforceRelativeLocation() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && tt.wantLocation != tt.resp.Header.Get("Location") {
+				t.Errorf("EnforceRelativeLocation() Location = %v, wantErr %v", tt.resp.Header.Get("Location"), tt.wantLocation)
+			}
+		})
+	}
+}
+
+func TestMultiResponseModifier_ModifyResponse(t *testing.T) {
+	tests := []struct {
+		name    string
+		mrs     MultiResponseModifier
+		resp    *http.Response
+		wantErr bool
+	}{
+		{
+			name:    "empty",
+			mrs:     MultiResponseModifier{},
+			resp:    &http.Response{},
+			wantErr: false,
+		},
+		{
+			name: "success",
+			mrs: MultiResponseModifier{
+				func(*http.Response) error {
+					return nil
+				},
+				func(*http.Response) error {
+					return nil
+				},
+			},
+			resp:    &http.Response{},
+			wantErr: false,
+		},
+		{
+			name: "error",
+			mrs: MultiResponseModifier{
+				func(*http.Response) error {
+					return nil
+				},
+				func(*http.Response) error {
+					return fmt.Errorf("")
+				},
+			},
+			resp:    &http.Response{},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.mrs.ModifyResponse(tt.resp); (err != nil) != tt.wantErr {
+				t.Errorf("MultiResponseModifier.ModifyResponse() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/new.go
+++ b/pkg/new.go
@@ -122,6 +122,9 @@ func New(ctx context.Context, specification []byte, components ...NewComponent) 
 			w.WriteHeader(http.StatusBadGateway)
 			_, _ = w.Write(b)
 		},
+		ModifyResponse: (MultiResponseModifier{
+			EnforceRelativeLocation,
+		}).ModifyResponse,
 	}
 
 	// Load and configure the runtime settings.


### PR DESCRIPTION
The ReverseProxy does not directly handle redirects and, instead, sends the
3xx response back to the caller. If the Location header provided by the redirect
is absolute (http://localhost/path/to/api) instead of relative (/path/to/api) it
results in clients making a second request to the remote system instead of making
another requests through the proxy. This addition ensures that all Location
headers returned by the proxy contain relative URLs so subsequent requests are
always targeted to the proxy.