### PR TITLE
WIP: Authorization based on LDAP group membership

### DIFF
--- a/pkg/components/defaults.go
+++ b/pkg/components/defaults.go
@@ -21,5 +21,6 @@ var (
 		Strip,
 		Header,
 		BasicAuth,
+		Auth,
 	}
 )

--- a/pkg/components/fine_grain_auth.go
+++ b/pkg/components/fine_grain_auth.go
@@ -1,0 +1,42 @@
+package components
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+type authHeader struct {
+	Wrapped http.RoundTripper
+}
+
+func (r *authHeader) RoundTrip(req *http.Request) (*http.Response, error){
+	header := req.Header
+	header.Del("Authorization")
+	fmt.Println(header)
+	return r.Wrapped.RoundTrip(req)
+}
+
+type AuthConfig struct {}
+
+func (*AuthConfig) Name() string {
+	return "authconfig"
+}
+
+type AuthConfigComponent struct {}
+
+func Auth(_ context.Context, _ string, _ string, _ string) (interface{}, error) {
+	return &AuthConfigComponent{}, nil
+}
+
+func (*AuthConfigComponent) Settings() *AuthConfig {
+	return &AuthConfig{}
+}
+
+func (*AuthConfigComponent) New(_ context.Context, conf *AuthConfig) (func(tripper http.RoundTripper) http.RoundTripper, error) {
+	return func(wrapped http.RoundTripper) http.RoundTripper {
+		return &authHeader{
+			Wrapped: wrapped,
+		}
+	}, nil
+}

--- a/pkg/components/fine_grain_auth.go
+++ b/pkg/components/fine_grain_auth.go
@@ -21,7 +21,7 @@ func Contains(s []string, target string) bool{
 func (r *authHeader) RoundTrip(req *http.Request) (*http.Response, error){
 	incomingLdapGroups := req.Header["X-Slauth-User-Groups"]
 	// We can probably load this from a yaml file somewhere? or where should we load this from?
-	whitelist := []string{"ciso-security-all"}
+	whitelist := []string{"some_ldap_group"}
 
 	for _, g:= range incomingLdapGroups{
 		if Contains(whitelist, g){

--- a/pkg/components/fine_grain_auth.go
+++ b/pkg/components/fine_grain_auth.go
@@ -20,7 +20,7 @@ func Contains(s []string, target string) bool{
 
 func (r *authHeader) RoundTrip(req *http.Request) (*http.Response, error){
 	incomingLdapGroups := req.Header["X-Slauth-User-Groups"]
-	// We can probably load this from yaml somewhere? where load this from?
+	// We can probably load this from a yaml file somewhere? or where should we load this from?
 	whitelist := []string{"ciso-security-all"}
 
 	for _, g:= range incomingLdapGroups{


### PR DESCRIPTION
**THIS IS A WORK IN PROGRESS**

Adding  a plugin that will allow you to selectively authorize a client based on ldap membership that is sent over by slauth.

**TODO:**
- [x] Add initial boilerplate for new plugin
- [x] Get current ldap group membership information from the headers
- [ ] Figure out where to get our ldap group whitelist from and how services will configure this.
- [ ] Add tests