### PR TITLE
Add leading slash to stripped path

### DIFF
--- a/pkg/components/strip.go
+++ b/pkg/components/strip.go
@@ -13,7 +13,7 @@ type strippingTransport struct {
 }
 
 func (r *strippingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.URL.Path = path.Join(strings.Split(req.URL.Path, "/")[r.Count+1:]...)
+	req.URL.Path = "/" + path.Join(strings.Split(req.URL.Path, "/")[r.Count+1:]...)
 	return r.Wrapped.RoundTrip(req)
 }
 

--- a/pkg/components/strip_test.go
+++ b/pkg/components/strip_test.go
@@ -17,10 +17,12 @@ func TestStripTransport(t *testing.T) {
 		Wrapped: rt,
 		Count:   2,
 	}
-	req, _ := http.NewRequest(http.MethodGet, "https://localhost/one/two/three/four", http.NoBody)
+	u := "https://localhost/one/two/three/four"
+	req, _ := http.NewRequest(http.MethodGet, u, http.NoBody)
 
 	rt.EXPECT().RoundTrip(gomock.Any()).Do(func(r *http.Request) {
 		assert.Equal(t, "https://localhost/three/four", r.URL.String())
+		assert.Equal(t, "/three/four", r.URL.Path)
 	}).Return(nil, nil)
 	_, _ = c.RoundTrip(req)
 }


### PR DESCRIPTION
The original form did not add a preceding slash character to the URL
path which resulting in faulty URLs. Even though the string representation
printed correctly the request path was not valid.