### PR TITLE
fixed makefile dep command to use go mod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,7 @@ TAG := $(shell git rev-parse --short HEAD)
 DIR := $(shell pwd -L)
 
 dep:
-	docker run -ti \
-        --mount src="$(DIR)",target="$(DIR)",type="bind" \
-        -w "$(DIR)" \
-        asecurityteam/sdcli:v1 go dep
+	GO111MODULE=on go mod vendor
 
 lint:
 	docker run -ti \


### PR DESCRIPTION
Now that `make dep` no longer works since we're off `dep`, I converted it to use go mod.

This command works for me locally, are reviewers ok with using this from now on or should we use a different command?