### PR TITLE
Update header validation plugin to accept any matching values

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
         - [Route Settings](#route-settings)
         - [Environment Variables](#environment-variables)
     - [Custom Plugins And Builds](#custom-plugins-and-builds)
+        - [Custom Components](#custom-components)
         - [Writing A Component](#writing-a-component)
         - [Generating A Build](#generating-a-build)
     - [Using As A Library](#using-as-a-library)

--- a/README.md
+++ b/README.md
@@ -264,6 +264,12 @@ alternatives to the standard library `plugin` package all require some form of
 multi-processing and RPC. Because of this, adding features beyond the core set
 requires creating a custom build of this project.
 
+<a id="custom-components" name="custom-components"></a>
+### Custom Components
+
+Documentation for custom components that handle things such as header validation can be found at [docs/components.md](docs/components.md)
+
+
 <a id="markdown-writing-a-component" name="writing-a-component"></a>
 ### Writing A Component
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -12,7 +12,7 @@ and if the configured value exists. If it can't find any configured header or co
 This makes the plugin flexible to check for the presence of any header values combination. It does not currently do strict matching
 if you want to validate that *multiple* values exist.
 
-Example: This configuration would verify that a header named `LdapGroups` exists and that it has any of the listed values `hr` or `pm`.
+Example: This configuration would verify that a header named `Ldap-Groups` exists and that it has any of the listed values `hr` or `pm`.
 ```yaml
 validateheaders:
   allowed:
@@ -22,7 +22,7 @@ validateheaders:
 ```
 
 
-Example: This configuration would verify that a header named `LdapGroups` or `Username` exists with any of the listed values for that header.
+Example: This configuration would verify that a header named `Ldap-Groups` or `Username` exists with any of the listed values for that header.
 ```yaml
 validateheaders:
   allowed:

--- a/docs/components.md
+++ b/docs/components.md
@@ -1,0 +1,35 @@
+### Custom Components
+This page will document some of the custom components of transportd and how they can be used by consumers.
+
+##### Validate Headers
+
+The `validate_headers` component can be used to validate the presence of headers and the existence of specific values in those headers.
+It verifies that *any* of the specified headers exist with *any* of the specified values for that header. Each key under `allowed`
+is the header name and the list of values for that key represent the the values we want to verify exist.
+
+If a configured header does not exist, or the specified value is not found, it will check for the next `allowed` header, if configured,
+and if the configured value exists. If it can't find any configured header or configured value for that header, it will reject the request.
+This makes the plugin flexible to check for the presence of any header values combination. It does not currently do strict matching
+if you want to validate that *multiple* values exist.
+
+Example: This configuration would verify that a header named `LdapGroups` exists and that it has any of the listed values `hr` or `pm`.
+```yaml
+validateheaders:
+  allowed:
+    ldap-groups:
+      - "hr"
+      - "pm"
+```
+
+
+Example: This configuration would verify that a header named `LdapGroups` or `Username` exists with any of the listed values for that header.
+```yaml
+validateheaders:
+  allowed:
+    ldap-groups:
+      - "hr"
+      - "pm"
+    username:
+      - "cloud-admin"
+```
+

--- a/docs/components.md
+++ b/docs/components.md
@@ -4,7 +4,7 @@ This page will document some of the custom components of transportd and how they
 ##### Validate Headers
 
 The `validate_headers` component can be used to validate the presence of headers and the existence of specific values in those headers.
-It verifies that *any* of the specified headers exist with *any* of the specified values for that header. Each key under `allowed`
+It verifies that at least one specified header contains at least one specified value. Each key under `allowed`
 is the header name and the list of values for that key represent the the values we want to verify exist.
 
 If a configured header does not exist, or the specified value is not found, it will check for the next `allowed` header, if configured,

--- a/pkg/components/validate_headers.go
+++ b/pkg/components/validate_headers.go
@@ -22,10 +22,10 @@ func contains(s []string, target string) bool {
 
 func incomingMatchesRequired(allowed map[string][]string, incoming map[string][]string) error {
 	checkedHeaderAndValues := make(map[string][]string)
-	for requiredKey, requiredValues := range allowed {
-		if matchedIncomingHeaderValues, present := incoming[http.CanonicalHeaderKey(requiredKey)]; present {
-			for _, item := range requiredValues {
-				checkedHeaderAndValues[requiredKey] = append(checkedHeaderAndValues[requiredKey], item)
+	for allowedKey, allowedValues := range allowed {
+		if matchedIncomingHeaderValues, present := incoming[http.CanonicalHeaderKey(allowedKey)]; present {
+			for _, item := range allowedValues {
+				checkedHeaderAndValues[allowedKey] = append(checkedHeaderAndValues[allowedKey], item)
 				if contains(matchedIncomingHeaderValues, item) {
 					return nil
 				}
@@ -43,9 +43,9 @@ func (r *validateHeaderTransport) RoundTrip(req *http.Request) (*http.Response, 
 	return r.Wrapped.RoundTrip(req)
 }
 
-// ValidateHeaderConfig is used to validate a map of headers and their required values against an incoming requests headers
+// ValidateHeaderConfig is used to validate a map of headers and their allowed values against an incoming requests headers
 type ValidateHeaderConfig struct {
-	Required map[string][]string `description:"Map of headers to validate and the required values for those headers."`
+	Required map[string][]string `description:"Map of headers to validate and the allowed values for those headers."`
 }
 
 // Name of the config root

--- a/pkg/components/validate_headers.go
+++ b/pkg/components/validate_headers.go
@@ -21,19 +21,18 @@ func contains(s []string, target string) bool {
 }
 
 func incomingMatchesRequired(allowed map[string][]string, incoming map[string][]string) error {
-	matchedValueFound := false
+	checkedHeaderAndValues := make(map[string][]string)
 	for requiredKey, requiredValues := range allowed {
-		matchedIncomingHeaderValues := incoming[http.CanonicalHeaderKey(requiredKey)]
-		for _, item := range requiredValues {
-			if contains(matchedIncomingHeaderValues, item) {
-				return nil
+		if matchedIncomingHeaderValues, present := incoming[http.CanonicalHeaderKey(requiredKey)]; present {
+			for _, item := range requiredValues {
+				checkedHeaderAndValues[requiredKey] = append(checkedHeaderAndValues[requiredKey], item)
+				if contains(matchedIncomingHeaderValues, item) {
+					return nil
+				}
 			}
 		}
 	}
-	if !matchedValueFound {
-		return fmt.Errorf("no matching values for header %s. given values %v. acceptable values %v", requiredKey, requiredValues, matchedIncomingHeaderValues)
-	}
-	return nil
+	return fmt.Errorf("no matching values for headers: %s. given matching headers and values: %s", allowed, checkedHeaderAndValues)
 }
 
 func (r *validateHeaderTransport) RoundTrip(req *http.Request) (*http.Response, error) {

--- a/pkg/components/validate_headers.go
+++ b/pkg/components/validate_headers.go
@@ -21,13 +21,17 @@ func contains(s []string, target string) bool {
 }
 
 func incomingMatchesRequired(allowed map[string][]string, incoming map[string][]string) error {
+	matchedValueFound := false
 	for requiredKey, requiredValues := range allowed {
 		matchedIncomingHeaderValues := incoming[http.CanonicalHeaderKey(requiredKey)]
 		for _, item := range requiredValues {
-			if !contains(matchedIncomingHeaderValues, item) {
-				return fmt.Errorf("no matching values for header %s. given values %v. acceptable values %v", requiredKey, requiredValues, matchedIncomingHeaderValues)
+			if contains(matchedIncomingHeaderValues, item) {
+				return nil
 			}
 		}
+	}
+	if !matchedValueFound {
+		return fmt.Errorf("no matching values for header %s. given values %v. acceptable values %v", requiredKey, requiredValues, matchedIncomingHeaderValues)
 	}
 	return nil
 }

--- a/pkg/components/validate_headers_test.go
+++ b/pkg/components/validate_headers_test.go
@@ -46,6 +46,13 @@ func Test_incomingMatchesAllowed(t *testing.T) {
 			wantErr:        false,
 		},
 		{
+			name:           "single incoming header with a single allowed value and multiple allowed headers",
+			allowedHeader:  map[string][]string{"Ldap-Groups": {"sre"}, "Client": {"mobile"}},
+			incomingHeader: map[string][]string{"Ldap-Groups": {"sre"}},
+			wantResult:     true,
+			wantErr:        false,
+		},
+		{
 			name:           "incorrect incoming header value",
 			allowedHeader:  defaultAllowedHeaderAndValues,
 			incomingHeader: map[string][]string{"Ldap-Groups": {"design"}},

--- a/pkg/components/validate_headers_test.go
+++ b/pkg/components/validate_headers_test.go
@@ -69,7 +69,7 @@ func Test_incomingMatchesAllowed(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := incomingMatchesRequired(tt.allowedHeader, tt.incomingHeader)
+			err := incomingMatchesAllowed(tt.allowedHeader, tt.incomingHeader)
 			require.Equal(t, tt.wantErr, err != nil)
 		})
 	}
@@ -149,8 +149,8 @@ func Test_validateHeadersRoundTrip(t *testing.T) {
 			defer ctrl.Finish()
 			rt := NewMockRoundTripper(ctrl)
 			c := &validateHeaderTransport{
-				Wrapped:  rt,
-				Required: tt.allowedHeaders,
+				Wrapped: rt,
+				Allowed: tt.allowedHeaders,
 			}
 			r := &http.Request{Header: tt.testHeaders}
 			rt.EXPECT().RoundTrip(gomock.Any()).Return(

--- a/pkg/components/validate_headers_test.go
+++ b/pkg/components/validate_headers_test.go
@@ -18,16 +18,30 @@ func Test_incomingMatchesAllowed(t *testing.T) {
 		wantErr        bool
 	}{
 		{
-			name:           "good incoming header values",
+			name:           "multiple incoming header values with multiple allowed values",
 			allowedHeader:  defaultAllowedHeaderAndValues,
 			incomingHeader: map[string][]string{"Ldap-Groups": {"sre", "devs"}},
 			wantResult:     true,
 			wantErr:        false,
 		},
 		{
-			name:           "good single incoming header value",
+			name:           "multiple incoming header values with a single allowed value",
 			allowedHeader:  map[string][]string{"Ldap-Groups": {"devs"}},
 			incomingHeader: map[string][]string{"Ldap-Groups": {"sre", "devs"}},
+			wantResult:     true,
+			wantErr:        false,
+		},
+		{
+			name:           "single incoming header value with multiple allowed values",
+			allowedHeader:  defaultAllowedHeaderAndValues,
+			incomingHeader: map[string][]string{"Ldap-Groups": {"devs"}},
+			wantResult:     true,
+			wantErr:        false,
+		},
+		{
+			name:           "single incoming header value with a single allowed value",
+			allowedHeader:  map[string][]string{"Ldap-Groups": {"devs"}},
+			incomingHeader: map[string][]string{"Ldap-Groups": {"devs"}},
 			wantResult:     true,
 			wantErr:        false,
 		},
@@ -42,13 +56,6 @@ func Test_incomingMatchesAllowed(t *testing.T) {
 			name:           "missing specific incoming header",
 			allowedHeader:  defaultAllowedHeaderAndValues,
 			incomingHeader: map[string][]string{"meh": {"sre", "devs"}},
-			wantResult:     false,
-			wantErr:        true,
-		},
-		{
-			name:           "missing single incoming header value",
-			allowedHeader:  defaultAllowedHeaderAndValues,
-			incomingHeader: map[string][]string{"Ldap-Groups": {"devs"}},
 			wantResult:     false,
 			wantErr:        true,
 		},

--- a/tests/specs/complete.yaml
+++ b/tests/specs/complete.yaml
@@ -75,7 +75,7 @@ paths:
           - "strip"
           - "basicauth"
         validateheaders:
-          required:
+          allowed:
             accept:
               - "text/json"
               - "text/html"


### PR DESCRIPTION
Previously the `validate_headers` plugin required EVERY header configured to be present and EVERY listed value to be required or it would be rejected.

This is too strict since we want to be able to accept a request, even if it only has one of the configured headers or only has a single configured value for header.

I have switched naming conventions from `required` to `allowed` to indicate this is more flexible now.

Questions for reviewers:
- should I add a section to our README explaining how this plugin works? or is there a better place for this documentation(keeping it in mind we want it to be public)? should it go in this PR?

TODO:
- [x] include docs