### PR TITLE
fixing apache thrift dep issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,3 +37,5 @@ require (
 	golang.org/x/sys v0.0.0-20190225065934-cc5685c2db12 // indirect
 	golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2 // indirect
 )
+
+replace git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,7 @@ github.com/SermoDigital/jose v0.9.2-0.20161205224733-f6df55f235c2/go.mod h1:ARgC
 github.com/ajg/form v0.0.0-20160822230020-523a5da1a92f/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
+github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asecurityteam/component-connstate v0.1.0 h1:S+lGjbziF/RHo+l/gswhpM3KqYb+uauviLh44gqQy8k=
 github.com/asecurityteam/component-connstate v0.1.0/go.mod h1:VdNqIIK+CHbWbDv4COoyjAwkP3u4IoP5NVCQFBsyTSU=


### PR DESCRIPTION
If we don't want to use the go proxy, we can use this replace statement to point directly to github.

Terraform ran into a similar issue:
https://github.com/terraform-providers/terraform-provider-aws/pull/9990
https://github.com/hashicorp/terraform/issues/22664