### PR TITLE
added tests, fixed bug where value is a comma separated list of values

### DIFF
--- a/pkg/components/validate_headers.go
+++ b/pkg/components/validate_headers.go
@@ -16,7 +16,7 @@ func contains(s []string, target string) bool {
 	for _, c := range s {
 		// handle case where a header value is a comma separated list
 		for _, value := range strings.Split(c, ",") {
-			if target == value {
+			if target == strings.TrimSpace(value) {
 				return true
 			}
 		}

--- a/pkg/components/validate_headers_test.go
+++ b/pkg/components/validate_headers_test.go
@@ -14,63 +14,66 @@ func Test_incomingMatchesAllowed(t *testing.T) {
 		name           string
 		allowedHeader  map[string][]string
 		incomingHeader map[string][]string
-		wantResult     bool
 		wantErr        bool
 	}{
 		{
 			name:           "multiple incoming header values with multiple allowed values",
 			allowedHeader:  defaultAllowedHeaderAndValues,
 			incomingHeader: map[string][]string{"Ldap-Groups": {"sre", "devs"}},
-			wantResult:     true,
 			wantErr:        false,
 		},
 		{
 			name:           "multiple incoming header values with a single allowed value",
 			allowedHeader:  map[string][]string{"Ldap-Groups": {"devs"}},
 			incomingHeader: map[string][]string{"Ldap-Groups": {"sre", "devs"}},
-			wantResult:     true,
+			wantErr:        false,
+		},
+		{
+			name:           "multiple incoming header values separated by a comma with a single allowed value",
+			allowedHeader:  map[string][]string{"Ldap-Groups": {"devs"}},
+			incomingHeader: map[string][]string{"Ldap-Groups": {"sre,ops", "security,devs"}},
+			wantErr:        false,
+		},
+		{
+			name:           "single incoming header value separated by a comma with a single allowed value",
+			allowedHeader:  map[string][]string{"Ldap-Groups": {"ops"}},
+			incomingHeader: map[string][]string{"Ldap-Groups": {"security,ops"}},
 			wantErr:        false,
 		},
 		{
 			name:           "single incoming header value with multiple allowed values",
 			allowedHeader:  defaultAllowedHeaderAndValues,
 			incomingHeader: map[string][]string{"Ldap-Groups": {"devs"}},
-			wantResult:     true,
 			wantErr:        false,
 		},
 		{
 			name:           "single incoming header value with a single allowed value",
 			allowedHeader:  map[string][]string{"Ldap-Groups": {"devs"}},
 			incomingHeader: map[string][]string{"Ldap-Groups": {"devs"}},
-			wantResult:     true,
 			wantErr:        false,
 		},
 		{
 			name:           "single incoming header with a single allowed value and multiple allowed headers",
 			allowedHeader:  map[string][]string{"Ldap-Groups": {"sre"}, "Client": {"mobile"}},
 			incomingHeader: map[string][]string{"Ldap-Groups": {"sre"}},
-			wantResult:     true,
 			wantErr:        false,
 		},
 		{
 			name:           "incorrect incoming header value",
 			allowedHeader:  defaultAllowedHeaderAndValues,
 			incomingHeader: map[string][]string{"Ldap-Groups": {"design"}},
-			wantResult:     false,
 			wantErr:        true,
 		},
 		{
 			name:           "missing specific incoming header",
 			allowedHeader:  defaultAllowedHeaderAndValues,
 			incomingHeader: map[string][]string{"meh": {"sre", "devs"}},
-			wantResult:     false,
 			wantErr:        true,
 		},
 		{
 			name:           "missing incoming header and values",
 			allowedHeader:  defaultAllowedHeaderAndValues,
 			incomingHeader: map[string][]string{"": {""}},
-			wantResult:     false,
 			wantErr:        true,
 		},
 	}
@@ -113,6 +116,30 @@ func Test_contains(t *testing.T) {
 			sliceToCheck: []string{"dog"},
 			target:       "dog",
 			wantResult:   true,
+		},
+		{
+			name:         "target is present in a slice with values separated by a comma",
+			sliceToCheck: []string{"cat,dog"},
+			target:       "dog",
+			wantResult:   true,
+		},
+		{
+			name:         "target is not present in a slice with values separated by a comma",
+			sliceToCheck: []string{"cat,dog"},
+			target:       "fish",
+			wantResult:   false,
+		},
+		{
+			name:         "target is present in a slice with multiple values separated by a comma",
+			sliceToCheck: []string{"cat,dog", "fish,chicken"},
+			target:       "dog",
+			wantResult:   true,
+		},
+		{
+			name:         "target is not present in a slice with multiple values separated by a comma",
+			sliceToCheck: []string{"cat,dog", "fish,chicken"},
+			target:       "bird",
+			wantResult:   false,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/components/validate_headers_test.go
+++ b/pkg/components/validate_headers_test.go
@@ -59,9 +59,15 @@ func Test_incomingMatchesAllowed(t *testing.T) {
 			wantErr:        false,
 		},
 		{
-			name:           "incorrect incoming header value",
+			name:           "single incorrect incoming header value",
 			allowedHeader:  defaultAllowedHeaderAndValues,
 			incomingHeader: map[string][]string{"Ldap-Groups": {"design"}},
+			wantErr:        true,
+		},
+		{
+			name:           "multiple incorrect incoming header values with multiple allowed values",
+			allowedHeader:  defaultAllowedHeaderAndValues,
+			incomingHeader: map[string][]string{"Ldap-Groups": {"design", "finance"}},
 			wantErr:        true,
 		},
 		{
@@ -138,6 +144,18 @@ func Test_contains(t *testing.T) {
 		{
 			name:         "target is not present in a slice with multiple values separated by a comma",
 			sliceToCheck: []string{"cat,dog", "fish,chicken"},
+			target:       "bird",
+			wantResult:   false,
+		},
+		{
+			name:         "target is present in a slice with multiple values separated by a comma and a space",
+			sliceToCheck: []string{"cat, dog", "fish, chicken"},
+			target:       "dog",
+			wantResult:   true,
+		},
+		{
+			name:         "target is not present in a slice with multiple values separated by a comma and a space",
+			sliceToCheck: []string{"cat, dog", "fish, chicken"},
 			target:       "bird",
 			wantResult:   false,
 		},


### PR DESCRIPTION
Fixed a bug where a header value of comma separated items would not be matched.

- [x] Fix bug by splitting on a header value and `,`. This doesn't break things for a value without a `,` since go will just return the value anyway after doing the split even if no ,` is present.
- [x] Add unit tests to cover this edge case for checking if a value is present and not present
- [x] Add some comments for clarity and to improve readability
- [x] deploy and test this out in an environment 

**NOTE:**
I have made a separate ticket to make the header value we split on configurable and improve the error logs returned to clients. I would rather merge this pull request first to fix the blocking bug and do the improvements as a fast follow.