### PR TITLE
Add Godoc badge 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <a id="markdown-transportd---http-middleware-as-a-service" name="transportd---http-middleware-as-a-service"></a>
 # transportd - HTTP Middleware As A Service
-
+[![GoDoc](https://godoc.org/github.com/asecurityteam/transportd?status.svg)](https://godoc.org/github.com/asecurityteam/transportd)
 *Status: Incubation*
 
 <!-- TOC -->


### PR DESCRIPTION
The badge links to published Go documentation.