### PR TITLE
add ability to set (inject) response headers distinct from request he…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-<a id="markdown-transportd---http-middleware-as-a-service" name="transportd---http-middleware-as-a-service"></a>
 # transportd - HTTP Middleware As A Service
 [![GoDoc](https://godoc.org/github.com/asecurityteam/transportd?status.svg)](https://godoc.org/github.com/asecurityteam/transportd)
 [![Build Status](https://travis-ci.com/asecurityteam/transportd.png?branch=master)](https://travis-ci.com/asecurityteam/transportd)
@@ -6,27 +5,8 @@
 
 *Status: Incubation*
 
-<!-- TOC -->
+<!-- TOC -->autoauto- [transportd - HTTP Middleware As A Service](#transportd---http-middleware-as-a-service)auto    - [Overview](#overview)auto    - [Configuration](#configuration)auto        - [Runtime Settings](#runtime-settings)auto        - [Backend Settings](#backend-settings)auto        - [Route Settings](#route-settings)auto        - [Environment Variables](#environment-variables)auto    - [Custom Plugins And Builds](#custom-plugins-and-builds)auto        - [Custom Components](#custom-components)auto        - [Writing A Component](#writing-a-component)auto        - [Generating A Build](#generating-a-build)auto    - [Using As A Library](#using-as-a-library)auto    - [Contributing](#contributing)auto        - [License](#license)auto        - [Contributing Agreement](#contributing-agreement)autoauto<!-- /TOC -->
 
-- [transportd - HTTP Middleware As A Service](#transportd---http-middleware-as-a-service)
-    - [Overview](#overview)
-    - [Configuration](#configuration)
-        - [Runtime Settings](#runtime-settings)
-        - [Backend Settings](#backend-settings)
-        - [Route Settings](#route-settings)
-        - [Environment Variables](#environment-variables)
-    - [Custom Plugins And Builds](#custom-plugins-and-builds)
-        - [Custom Components](#custom-components)
-        - [Writing A Component](#writing-a-component)
-        - [Generating A Build](#generating-a-build)
-    - [Using As A Library](#using-as-a-library)
-    - [Contributing](#contributing)
-        - [License](#license)
-        - [Contributing Agreement](#contributing-agreement)
-
-<!-- /TOC -->
-
-<a id="markdown-overview" name="overview"></a>
 ## Overview
 
 This project aggregates all of our most effective tooling into an HTTP reverse proxy
@@ -65,14 +45,12 @@ For those kinds of features we recommend [Netflix's Zuul](https://github.com/Net
 with [Netflix's Eureka](https://github.com/Netflix/eureka) or
 [Lyft's Envoy](https://www.envoyproxy.io/).
 
-<a id="markdown-configuration" name="configuration"></a>
 ## Configuration
 
 This proxy is built around OpenAPI consumes an OpenAPI specification as configuration.
 It looks for a set of extensions at certain key points in the document. Below are
 each of the locations and extensions the system expects in order to run.
 
-<a id="markdown-runtime-settings" name="runtime-settings"></a>
 ### Runtime Settings
 
 The HTTP server is provided by another one of our libraries,
@@ -113,7 +91,6 @@ x-runtime:
     address: ":8080"
 ```
 
-<a id="markdown-backend-settings" name="backend-settings"></a>
 ### Backend Settings
 
 In addition to the runtime, the system also expects that all backend configurations
@@ -136,7 +113,6 @@ x-transportd:
       ttl: "1h0m0s"
 ```
 
-<a id="markdown-route-settings" name="route-settings"></a>
 ### Route Settings
 
 Each route in the OpenAPI specification will need its own `x-transportd`
@@ -159,7 +135,8 @@ x-transportd:
     - "requestvalidation"
     - "responsevalidation"
     - "strip"
-    - "headerinject"
+    - "requestheaderinject"
+    - "responseheaderinject"
     - "basicauth"
   # (string) Backend target for this route.
   backend: "backendName"
@@ -236,7 +213,12 @@ x-transportd:
   strip:
     # (int) Number of URL segments to remove from the beginning of the path before redirect.
     count: 0
-  headerinject:
+  requestheaderinject:
+    # ([]string) List of header names to inject.
+    names:
+    # ([]string) List of header values to inject.
+    values:
+  responseheaderinject:
     # ([]string) List of header names to inject.
     names:
     # ([]string) List of header values to inject.
@@ -248,7 +230,6 @@ x-transportd:
     password: ""
 ```
 
-<a id="markdown-environment-variables" name="environment-variables"></a>
 ### Environment Variables
 
 For cases where a static YAML file is insufficient, such as deploying to multiple
@@ -260,7 +241,6 @@ environment variable value that is identified by the name inside the pattern.
 For example, `${FOO}` will result in the `FOO` environment variable being fetched
 and the value inserted.
 
-<a id="markdown-custom-plugins-and-builds" name="custom-plugins-and-builds"></a>
 ## Custom Plugins And Builds
 
 Unfortunately, go does not have good support for dynamic loading of plugins and the
@@ -274,7 +254,6 @@ requires creating a custom build of this project.
 Documentation for custom components that handle things such as header validation can be found at [docs/components.md](docs/components.md)
 
 
-<a id="markdown-writing-a-component" name="writing-a-component"></a>
 ### Writing A Component
 
 This project uses another one of our libraries, [settings](https://github.com/asecurityteam/settings),
@@ -384,7 +363,6 @@ func (*TimeoutComponent) New(_ context.Context, conf *TimeoutConfig) (func(http.
 }
 ```
 
-<a id="markdown-generating-a-build" name="generating-a-build"></a>
 ### Generating A Build
 
 Creating a custom build is equivalent to copying the `main.go` from this project
@@ -460,7 +438,6 @@ func main() {
 }
 ```
 
-<a id="markdown-using-as-a-library" name="using-as-a-library"></a>
 ## Using As A Library
 
 While the source projects like
@@ -485,15 +462,12 @@ The resulting `http.RoundTripper` implements all of the smart functionality of t
 reverse proxy but is exposed as a component that can be embedded in code and used
 anywhere an HTTP client would otherwise be used.
 
-<a id="markdown-contributing" name="contributing"></a>
 ## Contributing
 
-<a id="markdown-license" name="license"></a>
 ### License
 
 This project is licensed under Apache 2.0. See LICENSE.txt for details.
 
-<a id="markdown-contributing-agreement" name="contributing-agreement"></a>
 ### Contributing Agreement
 
 Atlassian requires signing a contributor's agreement before we can accept a

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<a id="markdown-transportd---http-middleware-as-a-service" name="transportd---http-middleware-as-a-service"></a>
 # transportd - HTTP Middleware As A Service
 [![GoDoc](https://godoc.org/github.com/asecurityteam/transportd?status.svg)](https://godoc.org/github.com/asecurityteam/transportd)
 [![Build Status](https://travis-ci.com/asecurityteam/transportd.png?branch=master)](https://travis-ci.com/asecurityteam/transportd)
@@ -5,7 +6,25 @@
 
 *Status: Incubation*
 
-<!-- TOC -->autoauto- [transportd - HTTP Middleware As A Service](#transportd---http-middleware-as-a-service)auto    - [Overview](#overview)auto    - [Configuration](#configuration)auto        - [Runtime Settings](#runtime-settings)auto        - [Backend Settings](#backend-settings)auto        - [Route Settings](#route-settings)auto        - [Environment Variables](#environment-variables)auto    - [Custom Plugins And Builds](#custom-plugins-and-builds)auto        - [Custom Components](#custom-components)auto        - [Writing A Component](#writing-a-component)auto        - [Generating A Build](#generating-a-build)auto    - [Using As A Library](#using-as-a-library)auto    - [Contributing](#contributing)auto        - [License](#license)auto        - [Contributing Agreement](#contributing-agreement)autoauto<!-- /TOC -->
+<!-- TOC -->
+
+- [transportd - HTTP Middleware As A Service](#transportd---http-middleware-as-a-service)
+    - [Overview](#overview)
+    - [Configuration](#configuration)
+        - [Runtime Settings](#runtime-settings)
+        - [Backend Settings](#backend-settings)
+        - [Route Settings](#route-settings)
+        - [Environment Variables](#environment-variables)
+    - [Custom Plugins And Builds](#custom-plugins-and-builds)
+        - [Custom Components](#custom-components)
+        - [Writing A Component](#writing-a-component)
+        - [Generating A Build](#generating-a-build)
+    - [Using As A Library](#using-as-a-library)
+    - [Contributing](#contributing)
+        - [License](#license)
+        - [Contributing Agreement](#contributing-agreement)
+
+<!-- /TOC -->
 
 ## Overview
 
@@ -45,12 +64,14 @@ For those kinds of features we recommend [Netflix's Zuul](https://github.com/Net
 with [Netflix's Eureka](https://github.com/Netflix/eureka) or
 [Lyft's Envoy](https://www.envoyproxy.io/).
 
+<a id="markdown-configuration" name="configuration"></a>
 ## Configuration
 
 This proxy is built around OpenAPI consumes an OpenAPI specification as configuration.
 It looks for a set of extensions at certain key points in the document. Below are
 each of the locations and extensions the system expects in order to run.
 
+<a id="markdown-runtime-settings" name="runtime-settings"></a>
 ### Runtime Settings
 
 The HTTP server is provided by another one of our libraries,
@@ -91,6 +112,7 @@ x-runtime:
     address: ":8080"
 ```
 
+<a id="markdown-backend-settings" name="backend-settings"></a>
 ### Backend Settings
 
 In addition to the runtime, the system also expects that all backend configurations
@@ -113,6 +135,7 @@ x-transportd:
       ttl: "1h0m0s"
 ```
 
+<a id="markdown-route-settings" name="route-settings"></a>
 ### Route Settings
 
 Each route in the OpenAPI specification will need its own `x-transportd`
@@ -214,15 +237,13 @@ x-transportd:
     # (int) Number of URL segments to remove from the beginning of the path before redirect.
     count: 0
   requestheaderinject:
-    # ([]string) List of header names to inject.
-    names:
-    # ([]string) List of header values to inject.
-    values:
+    # (map[string]string) Map values of header names:values to inject.
+    x-header-1: value1
+    x-header-2: value2
   responseheaderinject:
-    # ([]string) List of header names to inject.
-    names:
-    # ([]string) List of header values to inject.
-    values:
+    # (map[string]string) Map values of header names:values to inject.
+    x-header-1: value1
+    x-header-2: value2
   basicauth:
     # (string) Username to use in HTTP basic authentication.
     username: ""
@@ -230,6 +251,7 @@ x-transportd:
     password: ""
 ```
 
+<a id="markdown-environment-variables" name="environment-variables"></a>
 ### Environment Variables
 
 For cases where a static YAML file is insufficient, such as deploying to multiple
@@ -241,6 +263,7 @@ environment variable value that is identified by the name inside the pattern.
 For example, `${FOO}` will result in the `FOO` environment variable being fetched
 and the value inserted.
 
+<a id="markdown-custom-plugins-and-builds" name="custom-plugins-and-builds"></a>
 ## Custom Plugins And Builds
 
 Unfortunately, go does not have good support for dynamic loading of plugins and the
@@ -254,6 +277,7 @@ requires creating a custom build of this project.
 Documentation for custom components that handle things such as header validation can be found at [docs/components.md](docs/components.md)
 
 
+<a id="markdown-writing-a-component" name="writing-a-component"></a>
 ### Writing A Component
 
 This project uses another one of our libraries, [settings](https://github.com/asecurityteam/settings),
@@ -363,6 +387,7 @@ func (*TimeoutComponent) New(_ context.Context, conf *TimeoutConfig) (func(http.
 }
 ```
 
+<a id="markdown-generating-a-build" name="generating-a-build"></a>
 ### Generating A Build
 
 Creating a custom build is equivalent to copying the `main.go` from this project
@@ -438,6 +463,7 @@ func main() {
 }
 ```
 
+<a id="markdown-using-as-a-library" name="using-as-a-library"></a>
 ## Using As A Library
 
 While the source projects like
@@ -462,12 +488,15 @@ The resulting `http.RoundTripper` implements all of the smart functionality of t
 reverse proxy but is exposed as a component that can be embedded in code and used
 anywhere an HTTP client would otherwise be used.
 
+<a id="markdown-contributing" name="contributing"></a>
 ## Contributing
 
+<a id="markdown-license" name="license"></a>
 ### License
 
 This project is licensed under Apache 2.0. See LICENSE.txt for details.
 
+<a id="markdown-contributing-agreement" name="contributing-agreement"></a>
 ### Contributing Agreement
 
 Atlassian requires signing a contributor's agreement before we can accept a

--- a/README.md
+++ b/README.md
@@ -238,13 +238,19 @@ x-transportd:
     # (int) Number of URL segments to remove from the beginning of the path before redirect.
     count: 0
   requestheaderinject:
-    # (map[string]string) Map values of header names:values to inject.
-    x-header-1: value1
-    x-header-2: value2
+    # (map[string][]string) Map values of header names:values to inject.
+    headers:
+      x-header-1:
+        - "value1"
+      x-header-2:
+        - "value2"
   responseheaderinject:
-    # (map[string]string) Map values of header names:values to inject.
-    x-header-1: value1
-    x-header-2: value2
+    # (map[string][]string) Map values of header names:values to inject.
+    headers:
+      x-header-1:
+        - "value1"
+      x-header-2:
+        - "value2"
   basicauth:
     # (string) Username to use in HTTP basic authentication.
     username: ""

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 
 <!-- /TOC -->
 
+<a id="markdown-overview" name="overview"></a>
 ## Overview
 
 This project aggregates all of our most effective tooling into an HTTP reverse proxy

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/asecurityteam/logevent v1.1.0
 	github.com/asecurityteam/runhttp v0.3.0
 	github.com/asecurityteam/settings v0.3.0
-	github.com/asecurityteam/transport v1.2.0
+	github.com/asecurityteam/transport v1.3.0
 	github.com/getkin/kin-openapi v0.0.0-20190729060947-8785b416cb32
 	github.com/gobuffalo/buffalo-plugins v1.13.0 // indirect
 	github.com/gobuffalo/gogen v0.0.0-20190224213239-1c6076128bbc // indirect
@@ -30,6 +30,7 @@ require (
 	github.com/vincent-petithory/dataurl v0.0.0-20160330182126-9a301d65acbb
 	golang.org/x/net v0.0.0-20190930134127-c5a3c61f89f3 // indirect
 	golang.org/x/sys v0.0.0-20190225065934-cc5685c2db12 // indirect
+	golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2 // indirect
 	gopkg.in/yaml.v2 v2.2.3 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/asecurityteam/transport v0.0.0-20190225122138-b848ebf618ee h1:pcVkgdO
 github.com/asecurityteam/transport v0.0.0-20190225122138-b848ebf618ee/go.mod h1:0OVTikRn0uMRQsFsslN4ozUaD5YaRPUpqHTBzTsOtaM=
 github.com/asecurityteam/transport v1.2.0 h1:KY+ipAiFzp7lHbizWD0X0DLqVXk33n3Q9F2sltPK4mw=
 github.com/asecurityteam/transport v1.2.0/go.mod h1:nR1f2IiW3IIw2VxC7NOkZnwRhXanNE6XdnnIZctKbIU=
+github.com/asecurityteam/transport v1.3.0 h1:UYcKPxnAEeGVkicefWtIL/nJys/BlwYUdNxLwvi49so=
+github.com/asecurityteam/transport v1.3.0/go.mod h1:nR1f2IiW3IIw2VxC7NOkZnwRhXanNE6XdnnIZctKbIU=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
@@ -309,6 +311,7 @@ github.com/golang/mock v0.0.0-20190508161146-9fa652df1129/go.mod h1:sBzyDLLjw3U8
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0 h1:28o5sBqPkBsMGnC6b4MvE2TzSr5/AT4c/1fLqVGIwlk=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
+github.com/golang/mock v1.3.1 h1:qGJ6qTW+x6xX/my+8YUVl4WNpX9B7+/l2tRsHGZ7f2s=
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -512,6 +515,7 @@ golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190225124518-7f87c0fbb88b h1:+/WWzjwW6gidDJnMKWLKLX1gxn7irUTF1fLpQovfQ5M=
 golang.org/x/crypto v0.0.0-20190225124518-7f87c0fbb88b/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -607,6 +611,7 @@ golang.org/x/tools v0.0.0-20190219185102-9394956cfdc5/go.mod h1:E6PF97AdD6v0s+fP
 golang.org/x/tools v0.0.0-20190221204921-83362c3779f5 h1:ev5exjGDsOo0NPTB0qdCcE53BfWl1IICJlhgXgfT9fM=
 golang.org/x/tools v0.0.0-20190221204921-83362c3779f5/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/tools v0.0.0-20190425163242-31fd60d6bfdc h1:N3zlSgxkefUH/ecsl37RWTkESTB026kmXzNly8TuZCI=
 golang.org/x/tools v0.0.0-20190425163242-31fd60d6bfdc/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 google.golang.org/api v0.0.0-20180910000450-7ca32eb868bf/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.0.0-20181030000543-1d582fd0359e/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=

--- a/pkg/components/defaults.go
+++ b/pkg/components/defaults.go
@@ -19,7 +19,8 @@ var (
 		RequestValidation,
 		ResponseValidation,
 		Strip,
-		Header,
+		RequestHeader,
+		ResponseHeader,
 		BasicAuth,
 		ValidateHeaders,
 	}

--- a/pkg/components/header.go
+++ b/pkg/components/header.go
@@ -8,38 +8,38 @@ import (
 	"github.com/asecurityteam/transport"
 )
 
-// HeaderConfig configures automated header injection.
-type HeaderConfig struct {
+// RequestHeaderConfig configures automated header injection.
+type RequestHeaderConfig struct {
 	Names  []string `description:"List of header names to inject."`
 	Values []string `description:"List of header values to inject."`
 }
 
 // Name of the config root.
-func (*HeaderConfig) Name() string {
-	return "headerinject"
+func (*RequestHeaderConfig) Name() string {
+	return "requestheaderinject"
 }
 
-// HeaderComponent implements the settings.Component interface.
-type HeaderComponent struct{}
+// RequestHeaderComponent implements the settings.Component interface.
+type RequestHeaderComponent struct{}
 
-// Header satisfies the NewComponent signature.
-func Header(_ context.Context, _ string, _ string, _ string) (interface{}, error) {
-	return &HeaderComponent{}, nil
+// RequestHeader satisfies the NewComponent signature.
+func RequestHeader(_ context.Context, _ string, _ string, _ string) (interface{}, error) {
+	return &RequestHeaderComponent{}, nil
 }
 
 // Settings generates a config populated with defaults.
-func (*HeaderComponent) Settings() *HeaderConfig {
-	return &HeaderConfig{Names: []string{}, Values: []string{}}
+func (*RequestHeaderComponent) Settings() *RequestHeaderConfig {
+	return &RequestHeaderConfig{Names: []string{}, Values: []string{}}
 }
 
-func makeDecorator(name string, value string) transport.Decorator {
+func makeRequestDecorator(name string, value string) transport.Decorator {
 	return transport.NewHeader(func(*http.Request) (string, string) {
 		return name, value
 	})
 }
 
 // New generates the middleware.
-func (*HeaderComponent) New(_ context.Context, conf *HeaderConfig) (func(http.RoundTripper) http.RoundTripper, error) { // nolint
+func (*RequestHeaderComponent) New(_ context.Context, conf *RequestHeaderConfig) (func(http.RoundTripper) http.RoundTripper, error) { // nolint
 	if len(conf.Names) != len(conf.Values) {
 		return nil, fmt.Errorf(
 			"header mismatch. %d names. %d values. these must match",
@@ -49,7 +49,53 @@ func (*HeaderComponent) New(_ context.Context, conf *HeaderConfig) (func(http.Ro
 	}
 	ch := make(transport.Chain, 0, len(conf.Names))
 	for offset, name := range conf.Names {
-		ch = append(ch, makeDecorator(name, conf.Values[offset]))
+		ch = append(ch, makeRequestDecorator(name, conf.Values[offset]))
+	}
+	return ch.Apply, nil
+}
+
+// ResponseHeaderConfig configures automated header injection.
+type ResponseHeaderConfig struct {
+	Names  []string `description:"List of header names to inject."`
+	Values []string `description:"List of header values to inject."`
+}
+
+// Name of the config root.
+func (*ResponseHeaderConfig) Name() string {
+	return "responseheaderinject"
+}
+
+// ResponseHeaderComponent implements the settings.Component interface.
+type ResponseHeaderComponent struct{}
+
+// ResponseHeader satisfies the NewComponent signature.
+func ResponseHeader(_ context.Context, _ string, _ string, _ string) (interface{}, error) {
+	return &ResponseHeaderComponent{}, nil
+}
+
+// Settings generates a config populated with defaults.
+func (*ResponseHeaderComponent) Settings() *ResponseHeaderConfig {
+	return &ResponseHeaderConfig{Names: []string{}, Values: []string{}}
+}
+
+func makeResponseDecorator(name string, value string) transport.Decorator {
+	return transport.NewHeaders(nil, func(*http.Response) (string, string) {
+		return name, value
+	})
+}
+
+// New generates the middleware.
+func (*ResponseHeaderComponent) New(_ context.Context, conf *ResponseHeaderConfig) (func(http.RoundTripper) http.RoundTripper, error) { // nolint
+	if len(conf.Names) != len(conf.Values) {
+		return nil, fmt.Errorf(
+			"header mismatch. %d names. %d values. these must match",
+			len(conf.Names),
+			len(conf.Values),
+		)
+	}
+	ch := make(transport.Chain, 0, len(conf.Names))
+	for offset, name := range conf.Names {
+		ch = append(ch, makeResponseDecorator(name, conf.Values[offset]))
 	}
 	return ch.Apply, nil
 }

--- a/pkg/components/header_test.go
+++ b/pkg/components/header_test.go
@@ -12,15 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRequestHeaderInjectionConfigError(t *testing.T) {
-	cmp := &RequestHeaderComponent{}
-	set := cmp.Settings()
-	set.Names = []string{"one", "two"}
-	set.Values = []string{"one"}
-	_, err := cmp.New(context.Background(), set)
-	assert.Error(t, err)
-}
-
 func TestRequestHeaderInjection(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -28,8 +19,7 @@ func TestRequestHeaderInjection(t *testing.T) {
 	rt := NewMockRoundTripper(ctrl)
 	cmp := &RequestHeaderComponent{}
 	set := cmp.Settings()
-	set.Names = []string{"one", "two", "three"}
-	set.Values = []string{"a", "b", "c"}
+	set.Headers = map[string][]string{"one": {"a"}, "two": {"b"}, "three": {"c"}}
 	d, err := cmp.New(context.Background(), set)
 	assert.NoError(t, err)
 
@@ -52,8 +42,7 @@ func TestResponseHeaderInjection(t *testing.T) {
 	rt := NewMockRoundTripper(ctrl)
 	cmp := &ResponseHeaderComponent{}
 	set := cmp.Settings()
-	set.Names = []string{"one", "two", "three"}
-	set.Values = []string{"a", "b", "c"}
+	set.Headers = map[string][]string{"one": {"a"}, "two": {"b"}, "three": {"c"}}
 	d, err := cmp.New(context.Background(), set)
 	assert.NoError(t, err)
 
@@ -79,4 +68,5 @@ func TestResponseHeaderInjection(t *testing.T) {
 	assert.Equal(t, "b", resp.Header.Get("two"))
 	assert.Equal(t, "c", resp.Header.Get("three"))
 	assert.Equal(t, "d", resp.Header.Get("four"))
+
 }


### PR DESCRIPTION
…aders

Since the dependent [transport lib](https://github.com/asecurityteam/transport) now supports _response_ header injection in addition to just _request_ header injection, we can add config support in this project to distinguish between the two.

This PR _changes_ "headerinject" component to "requestheaderinject" and adds "responseheaderinject".

The use-case for this feature is so we can inject inbound request headers like `x-forwarded-for` when transportd is used as a proxy and inject outbound response headers like `cache-control` when transportd is used as a reverse proxy.

Because `headerinject` name is changed to `requestheaderinject` in this PR, I will subsequently push a _major_ version bump in the new tag.

---

It has been tested:

1.  made a little node app that just returns all the request headers it sees and adds a few response headers to ensure they're not clobbered by the new transportd feature:

```
app.get('/hello', (req, res) => {
  res.setHeader('content-type', 'application/json')
  res.setHeader('x-from-server', 'mike')
  res.end(JSON.stringify(req.headers))
})
```

2.  made a yaml file for the transportd configuration that demos the "requestheaderinject" and "responseheaderinject":

```
      x-transportd:
        backend: app
        enabled:
          - "requestheaderinject"
          - "responseheaderinject"
          - "responsevalidation"
        requestheaderinject:
          names:
            - "req-inject-one"
          values:
            - "ONE!"
        responseheaderinject:
          names:
            - "res-inject-two"
          values:
            - "TWO!"
```

3.  packaged it all up with docker compose, run it, test it with curl (with -v flag) to observe the results:

```
↪ curl -X GET "http://localhost:8080/hello" -v
Note: Unnecessary use of -X or --request, GET is already inferred.
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8080 (#0)
> GET /hello HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.54.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Content-Length: 141
< Content-Type: application/json
< Date: Fri, 18 Oct 2019 17:34:25 GMT
< Res-Inject-Two: TWO!
< X-From-Server: mike
< X-Powered-By: Express
<
* Connection #0 to host localhost left intact
{"host":"app:3000","user-agent":"curl/7.54.0","accept":"*/*","req-inject-one":"ONE!","x-forwarded-for":"172.25.0.1","accept-encoding":"gzip"}
```

Notice:
* the injected _request_ header was successfully injected:  `req-inject-one`
* the injected _response_ header was successfully injected:  `Res-Inject-Two`
* all response headers were preserved:  `X-From-Server`