### PR TITLE
set a no-op implementation for the authentication function so open ap…

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,7 @@ github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/getkin/kin-openapi v0.0.0-20190729060947-8785b416cb32 h1:I7Anq+p1fLtHbFkZ1MXMaV2PK6IiSN8IL9ST2S6uhwk=
 github.com/getkin/kin-openapi v0.0.0-20190729060947-8785b416cb32/go.mod h1:V1z9xl9oF5Wt7v32ne4FmiF1alpS4dM6mNzoywPOXlk=
+github.com/getkin/kin-openapi v0.3.0 h1:xsQ4mA20YJDMgIHdHqMKZ66QUe6/hi+x6yLsTTz8xyQ=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=

--- a/pkg/components/validate.go
+++ b/pkg/components/validate.go
@@ -24,6 +24,9 @@ func (r *inputValidatingTransport) RoundTrip(req *http.Request) (*http.Response,
 		Request:     req,
 		QueryParams: req.URL.Query(),
 		PathParams:  params,
+		Options: &openapi3filter.Options{
+			AuthenticationFunc: func(c context.Context, input *openapi3filter.AuthenticationInput) error { return nil },
+		},
 	}
 	err := openapi3filter.ValidateRequest(req.Context(), input)
 	if err != nil {

--- a/pkg/components/validator_test.go
+++ b/pkg/components/validator_test.go
@@ -41,6 +41,8 @@ paths:
           type: string
     get:
       description: Fetches a greeting.
+      security:
+        - BearerAuth: []
       operationId: hello
       parameters:
         - name: name
@@ -63,6 +65,10 @@ paths:
               schema:
                 type: string
 components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
   schemas:
     Greeting:
       required:


### PR DESCRIPTION
…i spec authors can document security

The `openapi3filter.ValidateRequest` demands that a function be declared on the Options struct that performs Authentication check when `security` is declared globally, or on an endpoint verb.  This PR introduces such a declaration that is implemented as a no-op.  Now spec authors can declare security in order to properly describe their APIs.