### PR TITLE
Allow unmatched routes for the default backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,20 +9,20 @@
 <!-- TOC -->
 
 - [transportd - HTTP Middleware As A Service](#transportd---http-middleware-as-a-service)
-    - [Overview](#overview)
-    - [Configuration](#configuration)
-        - [Runtime Settings](#runtime-settings)
-        - [Backend Settings](#backend-settings)
-        - [Route Settings](#route-settings)
-        - [Environment Variables](#environment-variables)
-    - [Custom Plugins And Builds](#custom-plugins-and-builds)
-        - [Custom Components](#custom-components)
-        - [Writing A Component](#writing-a-component)
-        - [Generating A Build](#generating-a-build)
-    - [Using As A Library](#using-as-a-library)
-    - [Contributing](#contributing)
-        - [License](#license)
-        - [Contributing Agreement](#contributing-agreement)
+  - [Overview](#overview)
+  - [Configuration](#configuration)
+    - [Runtime Settings](#runtime-settings)
+    - [Backend Settings](#backend-settings)
+    - [Route Settings](#route-settings)
+    - [Environment Variables](#environment-variables)
+  - [Custom Plugins And Builds](#custom-plugins-and-builds)
+    - [Custom Components](#custom-components)
+    - [Writing A Component](#writing-a-component)
+    - [Generating A Build](#generating-a-build)
+  - [Using As A Library](#using-as-a-library)
+  - [Contributing](#contributing)
+    - [License](#license)
+    - [Contributing Agreement](#contributing-agreement)
 
 <!-- /TOC -->
 
@@ -135,6 +135,32 @@ x-transportd:
       # (time.Duration) Lifetime of a pool before refreshing.
       ttl: "1h0m0s"
 ```
+
+If the proxy needs to allow unrecognized routes through to a backend then you
+must specify a backend with the name `default`. This backend must be given
+an extra key called `allowUnknown` that contains the equivalent of a route
+setting (documented in the next section). For example:
+
+```yaml
+x-transportd:
+  # ([]string) Available backends. Names are symbolic and referenced later.
+  backends:
+    - "default"
+  default:
+    # (string) Backend host URL.
+    host: "https://localhost"
+    pool:
+      # (int) Number of connections pools. Only use >1 if HTTP/2
+      count: 1
+      # (time.Duration) Lifetime of a pool before refreshing.
+      ttl: "1h0m0s"
+    allowUnknown:
+      enabled:
+        - "accesslog"
+```
+
+This configuration of middleware will be applied to all unknown route before
+they are proxied to the default backend.
 
 <a id="markdown-route-settings" name="route-settings"></a>
 ### Route Settings

--- a/pkg/basetransport.go
+++ b/pkg/basetransport.go
@@ -12,11 +12,12 @@ import (
 )
 
 const (
-	backendsSetting = "backends"
-	hostSetting     = "host"
-	countSetting    = "count"
-	ttlSetting      = "ttl"
-	poolSetting     = "pool"
+	defaultBackendName = "default"
+	backendsSetting    = "backends"
+	hostSetting        = "host"
+	countSetting       = "count"
+	ttlSetting         = "ttl"
+	poolSetting        = "pool"
 )
 
 type backendWrapper struct {

--- a/pkg/clienttransport.go
+++ b/pkg/clienttransport.go
@@ -42,7 +42,11 @@ type ClientTransport struct {
 }
 
 // RoundTrip performs a client lookup and uses the result to execute the
-// request. If a client is not found then a NotFound response it returned.
+// request.
+//
+// If a client is not found then a NotFound response it returned unless there
+// is a route for the path "unknown" and the method "unknown".
+//
 // If a client is found then the Route is injected into the request context
 // for later use.
 func (r *ClientTransport) RoundTrip(req *http.Request) (*http.Response, error) {

--- a/tests/new_test.go
+++ b/tests/new_test.go
@@ -31,6 +31,11 @@ func TestNewService(t *testing.T) {
 			Spec:    data.Bytes("missingruntime.yaml"),
 			WantErr: true,
 		},
+		{
+			Name:    "passthrough enabled",
+			Spec:    data.Bytes("passthroughenabled.yaml"),
+			WantErr: false,
+		},
 	}
 
 	for _, tt := range tcs {

--- a/tests/specs/passthroughenabled.yaml
+++ b/tests/specs/passthroughenabled.yaml
@@ -1,0 +1,193 @@
+openapi: 3.0.0
+x-runtime:
+  httpserver:
+    address: ":8080"
+  logger:
+    level: "INFO"
+    output: "STDOUT"
+  stats:
+    output: "NULL"
+    datadog:
+      address: "statsd:8126"
+      flushinterval: "10s"
+  signals:
+    installed:
+      - "OS"
+    os:
+      signals:
+        - 2 # SIGINT
+        - 15 # SIGTERM
+x-transportd:
+  backends:
+    - app
+    - default
+  app:
+    host: "https://localhost/"
+    pool:
+      ttl: "24h"
+      count: 1
+  default:
+    host: "https://localhost/"
+    pool:
+      ttl: "24h"
+      count: 1
+    allowUnknown:
+      enabled:
+        - "metrics"
+        - "validateheaders"
+        - "accesslog"
+        - "timeout"
+        - "hedging"
+        - "retry"
+        - "requestvalidation"
+        - "responsevalidation"
+        - "requestheaderinject"
+        - "responseheaderinject"
+        - "strip"
+        - "basicauth"
+      requestheaderinject:
+        headers:
+          x-header-1:
+            - "value1"
+          x-header-2:
+            - "value2"
+      responseheaderinject:
+        headers:
+          x-header-1:
+            - "value1"
+          x-header-2:
+            - "value2"
+      validateheaders:
+        allowed:
+          accept:
+            - "text/json"
+            - "text/html"
+          x-response-header:
+            - "value1"
+            - "value2"
+        split:
+          x-response-header: ","
+      timeout:
+        after: "175ms"
+      hedging:
+        interval: "50ms"
+      retry:
+        backoff: "50ms"
+        limit: 3
+        codes:
+          - 500
+          - 501
+          - 502
+          - 503
+          - 504
+          - 505
+          - 506
+          - 507
+          - 508
+          - 509
+          - 510
+          - 511
+      strip:
+        count: 0
+      basicauth:
+        username: "user"
+        password: "password"
+info:
+  version: 1.0.0
+  title: Sample specification
+  description: Used for testing
+  contact:
+    name: n/a
+    email: na@localhost.com
+  license:
+    name: Apache 2.0
+    url: "https://www.apache.org/licenses/LICENSE-2.0.html"
+paths:
+  /:
+    post:
+      description: Publish a message.
+      parameters:
+        - name: "topic"
+          in: "path"
+          description: "Logical topic name."
+          required: true
+          schema:
+            type: "string"
+        - name: "key"
+          in: "path"
+          description: "The partition key."
+          required: true
+          schema:
+            type: "string"
+      requestBody:
+        required: true
+        description: The event to publish.
+        application/octet-stream:
+          schema:
+            type: string
+            format: binary
+      responses:
+        "204":
+          description: "Success"
+      x-transportd:
+        enabled:
+          - "metrics"
+          - "validateheaders"
+          - "accesslog"
+          - "timeout"
+          - "hedging"
+          - "retry"
+          - "requestvalidation"
+          - "responsevalidation"
+          - "requestheaderinject"
+          - "responseheaderinject"
+          - "strip"
+          - "basicauth"
+        requestheaderinject:
+          headers:
+            x-header-1:
+              - "value1"
+            x-header-2:
+              - "value2"
+        responseheaderinject:
+          headers:
+            x-header-1:
+              - "value1"
+            x-header-2:
+              - "value2"
+        validateheaders:
+          allowed:
+            accept:
+              - "text/json"
+              - "text/html"
+            x-response-header:
+              - "value1"
+              - "value2"
+          split:
+            x-response-header: ","
+        backend: "app"
+        timeout:
+          after: "175ms"
+        hedging:
+          interval: "50ms"
+        retry:
+          backoff: "50ms"
+          limit: 3
+          codes:
+            - 500
+            - 501
+            - 502
+            - 503
+            - 504
+            - 505
+            - 506
+            - 507
+            - 508
+            - 509
+            - 510
+            - 511
+        strip:
+          count: 0
+        basicauth:
+          username: "user"
+          password: "password"


### PR DESCRIPTION
I'm attempting to introduce transportd for a series of services that
either have no OpenAPI specification or have one that is not guaranteed
to be correct. I'm looking to add an option that provides a bit of
forgiveness on an opt-in basis so that my teams can get started with the
proxy without needing their contracts to be perfect yet. I plan to
introduce the proxy with additional middleware that report on route
mismatches rather than denying them outright so folks have time to
update their specs.

This patch introduces an option to allow requests that do not match any
given OpenAPI path to still be proxied to a backend. This works by
establishing a canonical name for a default backend. Realisically,
there's no way to route unmatched paths to different backends as that is
among the core purposes of the route mapping to begin with. Establishing
that one and only one backend may receive unmatched routes resolves the
conflict. The next version of the OpenAPI spec _should_ include the
ability to use wildcards in routes in a way that would replace this
feature over time. There is no timeline for when that next version will
be available.

This patch ensures that anyone currently using the name "default", the
canon name for the default backend, is unaffected. The new behavior must
be opted into by adding a new section called "allowUnknown" which
contains a full suite of route settings that will be applied for all
unknown routes. This makes it possible to log, stat, etc., the unknown
routes before proxying them to the backend. The only difference between
the "allowUnknown" section and the "x-transportd" section typically
found under a route is that "allowUnknown" does not require a "backend"
key and any key of that name given is overwritten with "default". I did
this to avoid requiring the user to denote an obvious relationship.