### PR TITLE
Replace -1 status code with proper code based on error

### DIFF
--- a/pkg/components/accesslog.go
+++ b/pkg/components/accesslog.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/asecurityteam/runhttp"
+	transportd "github.com/asecurityteam/transportd/pkg"
 )
 
 type accessLog struct {
@@ -61,10 +62,11 @@ func (c *loggingTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	var start = time.Now()
 	var resp, e = c.Wrapped.RoundTrip(r)
 	a.Duration = int(time.Since(start).Nanoseconds() / 1e6)
-	a.Status = -1
 	if e == nil {
 		a.Status = resp.StatusCode
 		a.HTTPContentType = resp.Header.Get("Content-Type")
+	} else {
+		a.Status = transportd.ErrorToStatusCode(e)
 	}
 	runhttp.LoggerFromContext(r.Context()).Info(a)
 	return resp, e

--- a/pkg/errors.go
+++ b/pkg/errors.go
@@ -23,7 +23,7 @@ func newError(code int, reason string) *http.Response {
 	}
 }
 
-// There can be many reasons why we couldn't get a proper response from the upstream server.
+// ErrorToStatusCode There can be many reasons why we couldn't get a proper response from the upstream server.
 // This includes timeouts, inability to connect, or the client canceling a request.
 // This cannot all be captured with one status code. This method will convert golang errors to descriptive status codes.
 // context.Canceled: Something likely happened on the client side that canceled the request (such as a timeout), return 504
@@ -32,7 +32,6 @@ func newError(code int, reason string) *http.Response {
 func ErrorToStatusCode(err error) int {
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return http.StatusGatewayTimeout
-	} else {
-		return http.StatusBadGateway
 	}
+	return http.StatusBadGateway
 }

--- a/pkg/errors.go
+++ b/pkg/errors.go
@@ -2,7 +2,9 @@ package transportd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"net/http"
 )
@@ -18,5 +20,19 @@ func newError(code int, reason string) *http.Response {
 		StatusCode: code,
 		Header:     http.Header{"Content-Type": []string{"application/json"}},
 		Body:       ioutil.NopCloser(bytes.NewReader(b)),
+	}
+}
+
+// There can be many reasons why we couldn't get a proper response from the upstream server.
+// This includes timeouts, inability to connect, or the client canceling a request.
+// This cannot all be captured with one status code. This method will convert golang errors to descriptive status codes.
+// context.Canceled: Something likely happened on the client side that canceled the request (such as a timeout), return 504
+// context.DeadlineExceeded: Likely a timeout here in the proxy, return 504
+// Default: 502
+func ErrorToStatusCode(err error) int {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return http.StatusGatewayTimeout
+	} else {
+		return http.StatusBadGateway
 	}
 }

--- a/pkg/errors_test.go
+++ b/pkg/errors_test.go
@@ -1,0 +1,18 @@
+package transportd
+
+import (
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
+	"testing"
+)
+
+func TestErrorToStatusCode(t *testing.T) {
+	code := ErrorToStatusCode(context.Canceled)
+	assert.Equal(t, 504, code)
+
+	code = ErrorToStatusCode(context.DeadlineExceeded)
+	assert.Equal(t, 504, code)
+
+	code = ErrorToStatusCode(nil)
+	assert.Equal(t, 502, code)
+}

--- a/pkg/errors_test.go
+++ b/pkg/errors_test.go
@@ -1,9 +1,10 @@
 package transportd
 
 import (
-	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
+	"context"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestErrorToStatusCode(t *testing.T) {

--- a/pkg/new.go
+++ b/pkg/new.go
@@ -150,13 +150,14 @@ func New(ctx context.Context, specification []byte, components ...NewComponent) 
 			}{
 				Reason: err.Error(),
 			})
+			code := ErrorToStatusCode(err)
 			b, _ := json.Marshal(HTTPError{
-				Code:   http.StatusBadGateway,
-				Status: http.StatusText(http.StatusBadGateway),
+				Code:   code,
+				Status: http.StatusText(code),
 				Reason: err.Error(),
 			})
 			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusBadGateway)
+			w.WriteHeader(code)
 			_, _ = w.Write(b)
 		},
 		ModifyResponse: (MultiResponseModifier{


### PR DESCRIPTION
Currently when we get an exception on our proxy we log a status code of -1, but return a response with status code 502. This is confusing and non descriptive. Instead, it is better to log and return a descriptive status code.

A little extra info on the errors filtered for here:

When we get the error `context canceled` based on the docs (https://golang.org/pkg/net/http/#Request.Context) it should mean:
For incoming server requests, the context is canceled when the client's connection closes, the request is canceled (with HTTP/2), or when the ServeHTTP method returns.

When we get the error `context deadline exceeded` this means that our proxy has timed out. 

Open to any feedback! Especially what kind of status codes we want to return. As of this PR we would no longer get -1 status codes. This change will also be made in the HttpStats repo for the same reason. 