### PR TITLE
upgrade transport to v1.6.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/asecurityteam/logevent v1.5.0
 	github.com/asecurityteam/runhttp v0.3.0
 	github.com/asecurityteam/settings v0.4.0
-	github.com/asecurityteam/transport v1.6.1
+	github.com/asecurityteam/transport v1.6.2
 	github.com/getkin/kin-openapi v0.0.0-20190729060947-8785b416cb32
 	github.com/gobuffalo/buffalo-plugins v1.13.0 // indirect
 	github.com/gobuffalo/gogen v0.0.0-20190224213239-1c6076128bbc // indirect

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ github.com/asecurityteam/transport v1.6.0 h1:Nd3pd/ZP2uKQd2CHiwVGYlmTtS81fIP66LS
 github.com/asecurityteam/transport v1.6.0/go.mod h1:qfuYUhtdNiKiwrTAwCuBC2kZuLIyhHHYp5AleGc6uAE=
 github.com/asecurityteam/transport v1.6.1 h1:79m3pgBYRgCjIL7M2dFDZB8Cs4H4Msqk+/ljvdRjTQc=
 github.com/asecurityteam/transport v1.6.1/go.mod h1:qfuYUhtdNiKiwrTAwCuBC2kZuLIyhHHYp5AleGc6uAE=
+github.com/asecurityteam/transport v1.6.2 h1:zJCl1671VSeenGxvx+RWRtcBj57VFZL4UI6gBIF80fw=
+github.com/asecurityteam/transport v1.6.2/go.mod h1:qfuYUhtdNiKiwrTAwCuBC2kZuLIyhHHYp5AleGc6uAE=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=


### PR DESCRIPTION
... which fixes the mistreatment of the Retry-After header as milliseconds.  The proper treatment is as seconds.