### PR TITLE
Adding Principal logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ x-transportd:
     timing: "http.client.timing"
   accesslog:
     # (string) Name of Header to check for principal of request.
-    principalheader: "SUBJECT-HEADER"
+    principalheader: "X-Principal"
   asapvalidate:
     # ([]string) Public key download URLs.
     keyurls:

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ x-transportd:
   # (string) Backend target for this route.
   backend: "backendName"
   metrics:
-    # (string) Name of the tag containing the path referecne.
+    # (string) Name of the tag containing the path reference.
     pathtag: "client_path"
     # (string) Name of the tag containing the backend reference.
     backendtag: "client_dependency"
@@ -219,6 +219,9 @@ x-transportd:
     dns: "http.client.dns.timing"
     # (string) Name of overall timing metric.
     timing: "http.client.timing"
+  accesslog:
+    # (string) Name of Header to check for principal of request.
+    principalheader: "SUBJECT-HEADER"
   asapvalidate:
     # ([]string) Public key download URLs.
     keyurls:

--- a/pkg/components/accesslog.go
+++ b/pkg/components/accesslog.go
@@ -38,7 +38,8 @@ type accessLog struct {
 }
 
 type loggingTransport struct {
-	Wrapped http.RoundTripper
+	Wrapped         http.RoundTripper
+	PrincipalHeader string
 }
 
 // RoundTrip writes structured access logs for the request.
@@ -52,7 +53,7 @@ func (c *loggingTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 		Port:                   dstPort,
 		SourceIP:               srcIP,
 		Site:                   r.Host,
-		Principal:              r.Header.Get("X-Slauth-Subject"),
+		Principal:              r.Header.Get(c.PrincipalHeader),
 		HTTPRequestContentType: r.Header.Get("Content-Type"),
 		HTTPMethod:             r.Method,
 		HTTPReferrer:           r.Referer(),
@@ -75,7 +76,9 @@ func (c *loggingTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 }
 
 // AccessLogConfig modifies the behavior of the access logs.
-type AccessLogConfig struct{}
+type AccessLogConfig struct {
+	PrincipalHeader string `description:"Name of Header that describes the principal of the request."`
+}
 
 // Name of the config root.
 func (*AccessLogConfig) Name() string {
@@ -92,12 +95,14 @@ func AccessLog(_ context.Context, _ string, _ string, _ string) (interface{}, er
 
 // Settings generates a config populated with defaults.
 func (m *AccessLogComponent) Settings() *AccessLogConfig {
-	return &AccessLogConfig{}
+	return &AccessLogConfig{
+		PrincipalHeader: "X-Slauth-Subject",
+	}
 }
 
 // New generates the middleware.
 func (*AccessLogComponent) New(ctx context.Context, conf *AccessLogConfig) (func(http.RoundTripper) http.RoundTripper, error) {
 	return func(next http.RoundTripper) http.RoundTripper {
-		return &loggingTransport{Wrapped: next}
+		return &loggingTransport{Wrapped: next, PrincipalHeader: conf.PrincipalHeader}
 	}, nil
 }

--- a/pkg/components/accesslog.go
+++ b/pkg/components/accesslog.go
@@ -23,6 +23,7 @@ type accessLog struct {
 	HTTPMethod             string   `logevent:"http_method"`
 	HTTPReferrer           string   `logevent:"http_referrer"`
 	HTTPUserAgent          string   `logevent:"http_user_agent"`
+	Principal              string   `logevent:"principal"`
 	URIPath                string   `logevent:"uri_path"`
 	URIQuery               string   `logevent:"uri_query"`
 	Scheme                 string   `logevent:"scheme"`
@@ -51,6 +52,7 @@ func (c *loggingTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 		Port:                   dstPort,
 		SourceIP:               srcIP,
 		Site:                   r.Host,
+		Principal:              r.Header.Get("X-Slauth-Subject"),
 		HTTPRequestContentType: r.Header.Get("Content-Type"),
 		HTTPMethod:             r.Method,
 		HTTPReferrer:           r.Referer(),

--- a/pkg/components/accesslog.go
+++ b/pkg/components/accesslog.go
@@ -96,7 +96,7 @@ func AccessLog(_ context.Context, _ string, _ string, _ string) (interface{}, er
 // Settings generates a config populated with defaults.
 func (m *AccessLogComponent) Settings() *AccessLogConfig {
 	return &AccessLogConfig{
-		PrincipalHeader: "X-Slauth-Subject",
+		PrincipalHeader: "X-Principal",
 	}
 }
 

--- a/pkg/components/accesslog_test.go
+++ b/pkg/components/accesslog_test.go
@@ -12,6 +12,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func simpleResponse() *http.Response {
+	return &http.Response{
+		Status:     "200 OK",
+		StatusCode: http.StatusOK,
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header:     http.Header{},
+		Body:       http.NoBody,
+	}
+}
+
 func TestAccessLog(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -24,24 +36,74 @@ func TestAccessLog(t *testing.T) {
 		context.WithValue(req.Context(), http.LocalAddrContextKey, &net.IPAddr{Zone: "", IP: net.ParseIP("127.0.0.1")}),
 	)
 	req = req.WithContext(logevent.NewContext(req.Context(), logger))
-	req.Header.Add("X-Slauth-Subject", "some-user")
 	logger.EXPECT().Info(gomock.Any()).Do(func(event interface{}) {
 		assert.IsType(t, accessLog{}, event, "middleware did not perform an access log")
-		log := event.(accessLog)
-		assert.Equal(t, "some-user", log.Principal, "Principal was expected to be 'some-user'")
 	})
-	resp := &http.Response{
-		Status:     "200 OK",
-		StatusCode: http.StatusOK,
-		Proto:      "HTTP/1.1",
-		ProtoMajor: 1,
-		ProtoMinor: 1,
-		Header:     http.Header{},
-		Body:       http.NoBody,
-	}
-	rt.EXPECT().RoundTrip(gomock.Any()).Return(resp, nil).AnyTimes()
+	rt.EXPECT().RoundTrip(gomock.Any()).Return(simpleResponse(), nil).AnyTimes()
 	wrapped := &loggingTransport{
 		Wrapped: rt,
 	}
 	_, _ = wrapped.RoundTrip(req)
+}
+
+func TestPrincipalLogging(t *testing.T) {
+	tests := []struct {
+		name              string
+		expectedHeader    string
+		sentHeader        string
+		expectedPrincipal string
+		sentPrincipal     string
+	}{
+		{
+			name:              "Found Header",
+			expectedHeader:    "SUBJECT-HEADER",
+			sentHeader:        "SUBJECT-HEADER",
+			expectedPrincipal: "some-user",
+			sentPrincipal:     "some-user",
+		},
+		{
+			name:              "Expected wrong Header",
+			expectedHeader:    "X-Slauth-Subject",
+			sentHeader:        "SUBJECT-HEADER",
+			expectedPrincipal: "",
+			sentPrincipal:     "some-user",
+		},
+	}
+
+	//Base request and setup that doesn't need to change
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	logger := NewMockLogger(ctrl)
+	rt := NewMockRoundTripper(ctrl)
+
+	req := httptest.NewRequest(http.MethodGet, "https://localhost/", http.NoBody)
+	req = req.WithContext(
+		context.WithValue(req.Context(), http.LocalAddrContextKey, &net.IPAddr{Zone: "", IP: net.ParseIP("127.0.0.1")}),
+	)
+	req = req.WithContext(logevent.NewContext(req.Context(), logger))
+	rt.EXPECT().RoundTrip(gomock.Any()).Return(simpleResponse(), nil).AnyTimes()
+
+	//Tests for expectations
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req.Header.Add(tt.sentHeader, tt.sentPrincipal)
+
+			logger.EXPECT().Info(gomock.Any()).Do(func(event interface{}) {
+				assert.IsType(t, accessLog{}, event, "middleware did not perform an access log")
+				//Safe because we've already verified type
+				log := event.(accessLog)
+				assert.Equal(t, tt.expectedPrincipal, log.Principal)
+			})
+
+			wrapped := &loggingTransport{
+				Wrapped:         rt,
+				PrincipalHeader: tt.expectedHeader,
+			}
+			_, _ = wrapped.RoundTrip(req)
+
+			//Since we're reusing requests instead of remaking them each run
+			req.Header.Del(tt.sentHeader)
+		})
+	}
 }

--- a/pkg/components/accesslog_test.go
+++ b/pkg/components/accesslog_test.go
@@ -24,8 +24,11 @@ func TestAccessLog(t *testing.T) {
 		context.WithValue(req.Context(), http.LocalAddrContextKey, &net.IPAddr{Zone: "", IP: net.ParseIP("127.0.0.1")}),
 	)
 	req = req.WithContext(logevent.NewContext(req.Context(), logger))
+	req.Header.Add("X-Slauth-Subject", "some-user")
 	logger.EXPECT().Info(gomock.Any()).Do(func(event interface{}) {
 		assert.IsType(t, accessLog{}, event, "middleware did not perform an access log")
+		log := event.(accessLog)
+		assert.Equal(t, "some-user", log.Principal, "Principal was expected to be 'some-user'")
 	})
 	resp := &http.Response{
 		Status:     "200 OK",


### PR DESCRIPTION
This logs the principal of a request (in this case who or what's name this request is under) via a configurable header (thanks Kevin!). We default to X-Principal as a generic name that keeps people from having to configure something they don't care about.
