### PR TITLE
switch back to secdev

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @asecurityteam/prodsecdev
+*   @asecurityteam/secdev


### PR DESCRIPTION
Switching back to SecDev wide so we can still get some approvals outside of a specific team. We could conceptually just ask for reviews from specific teams and not enforce this on the code owners file level.