### PR TITLE
Log response body excluding request with status code less than 400

### DIFF
--- a/pkg/components/accesslog.go
+++ b/pkg/components/accesslog.go
@@ -69,7 +69,7 @@ func (c *loggingTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	if e == nil {
 		a.Status = resp.StatusCode
 		a.HTTPContentType = resp.Header.Get("Content-Type")
-		if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		if resp.StatusCode > 399 {
 			respData, err := io.ReadAll(resp.Body)
 			if err != nil {
 				runhttp.LoggerFromContext(r.Context()).Error(err)
@@ -78,6 +78,7 @@ func (c *loggingTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 		}
 	} else {
 		a.Status = transportd.ErrorToStatusCode(e)
+		a.Message = e.Error()
 	}
 	runhttp.LoggerFromContext(r.Context()).Info(a)
 	return resp, e

--- a/pkg/components/accesslog.go
+++ b/pkg/components/accesslog.go
@@ -2,6 +2,7 @@ package components
 
 import (
 	"context"
+	"io"
 	"net"
 	"net/http"
 	"strconv"
@@ -68,6 +69,13 @@ func (c *loggingTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	if e == nil {
 		a.Status = resp.StatusCode
 		a.HTTPContentType = resp.Header.Get("Content-Type")
+		if resp.StatusCode < 200 || resp.StatusCode > 299 {
+			respData, err := io.ReadAll(resp.Body)
+			if err != nil {
+				runhttp.LoggerFromContext(r.Context()).Error(err)
+			}
+			a.Message = string(respData)
+		}
 	} else {
 		a.Status = transportd.ErrorToStatusCode(e)
 	}


### PR DESCRIPTION
This pull request intends to log response bodies of requests with no error and do not have 2xx status code. The reason is 500 status codes are found in awsconfig-filterd logs without messages associated with them. By logging response body of 500 status code, we should have useful information to fix any error or bug.