### PR TITLE
Principal fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ x-transportd:
     # (string) Name of overall timing metric.
     timing: "http.client.timing"
   accesslog:
-    # (string) Name of Header to check for principal of request.
+    # (string) Name(s) of Header(s) to check for principal of request. Comma delimited list as a string, where each item is a fallback in case the other values are empty. 
     principalheader: "X-Principal"
   asapvalidate:
     # ([]string) Public key download URLs.

--- a/pkg/components/accesslog.go
+++ b/pkg/components/accesslog.go
@@ -89,7 +89,8 @@ func (c *loggingTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 func (c *loggingTransport) getPrincipal(r *http.Request) string {
 	potentialHeaders := strings.Split(c.PrincipalHeader, ",")
 	for _, header := range potentialHeaders {
-		principal := r.Header.Get(header)
+		cleanHeader := strings.TrimSpace(header)
+		principal := r.Header.Get(cleanHeader)
 		if len(principal) > 0 {
 			return principal
 		}


### PR DESCRIPTION
This PR modifies the `principalheader` to allow a comma delimited list of headers. The first header that does not return an empty value will be used for logging. So this works like a fallback system. 

We could arguably use a yaml array for this, but for backwards compatibility I thought this was the best way to go. 