### PR TITLE
validate the TTL is set to greater than zero

### DIFF
--- a/pkg/components/asap.go
+++ b/pkg/components/asap.go
@@ -115,9 +115,16 @@ func ASAPToken(_ context.Context, _ string, _ string, _ string) (interface{}, er
 	return &ASAPTokenComponent{}, nil
 }
 
+// NewComponent populates an ASAPToken with defaults.
+func NewComponent() *ASAPTokenComponent {
+	return &ASAPTokenComponent{}
+}
+
 // Settings generates a config populated with defaults.
 func (m *ASAPTokenComponent) Settings() *ASAPTokenConfig {
-	return &ASAPTokenConfig{}
+	return &ASAPTokenConfig{
+		TTL: time.Minute * -60,
+	}
 }
 
 // New generates the middleware.
@@ -133,6 +140,9 @@ func (*ASAPTokenComponent) New(ctx context.Context, conf *ASAPTokenConfig) (func
 	}
 	if len(conf.KID) < 1 {
 		return nil, fmt.Errorf("kid value is empty")
+	}
+	if conf.TTL == 0 || conf.TTL < 0 {
+		return nil, fmt.Errorf("ttl duration is invalid: %s", conf.TTL)
 	}
 	rawKey := conf.PrivateKey
 	if strings.HasPrefix(rawKey, "data:") {

--- a/pkg/components/asap.go
+++ b/pkg/components/asap.go
@@ -123,7 +123,7 @@ func NewComponent() *ASAPTokenComponent {
 // Settings generates a config populated with defaults.
 func (m *ASAPTokenComponent) Settings() *ASAPTokenConfig {
 	return &ASAPTokenConfig{
-		TTL: time.Minute * -60,
+		TTL: time.Minute * 60,
 	}
 }
 

--- a/pkg/components/asap.go
+++ b/pkg/components/asap.go
@@ -122,9 +122,7 @@ func NewComponent() *ASAPTokenComponent {
 
 // Settings generates a config populated with defaults.
 func (m *ASAPTokenComponent) Settings() *ASAPTokenConfig {
-	return &ASAPTokenConfig{
-		TTL: time.Minute * 60,
-	}
+	return &ASAPTokenConfig{}
 }
 
 // New generates the middleware.

--- a/pkg/components/asap.go
+++ b/pkg/components/asap.go
@@ -141,8 +141,8 @@ func (*ASAPTokenComponent) New(ctx context.Context, conf *ASAPTokenConfig) (func
 	if len(conf.KID) < 1 {
 		return nil, fmt.Errorf("kid value is empty")
 	}
-	if conf.TTL == 0 || conf.TTL < 0 {
-		return nil, fmt.Errorf("ttl duration is invalid: %s", conf.TTL)
+	if conf.TTL <= 0 {
+		return nil, fmt.Errorf("ttl duration is less than or equal to zero")
 	}
 	rawKey := conf.PrivateKey
 	if strings.HasPrefix(rawKey, "data:") {

--- a/pkg/components/asap_test.go
+++ b/pkg/components/asap_test.go
@@ -215,6 +215,26 @@ func TestASAPTokenComponent_New(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "invalid TTL - zero",
+			conf: &ASAPTokenConfig{
+				PrivateKey: string(pk),
+				KID:        kid,
+				TTL:        0,
+				Issuer:     iss,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid TTL - negative",
+			conf: &ASAPTokenConfig{
+				PrivateKey: string(pk),
+				KID:        kid,
+				TTL:        time.Second * -1,
+				Issuer:     iss,
+			},
+			wantErr: true,
+		},
+		{
 			name: "success",
 			conf: &ASAPTokenConfig{
 				PrivateKey: string(pk),


### PR DESCRIPTION
Recently had a situation where I forgot to set the TTL value for an ASAPTokenConfig, which results in TTL being set to the `time.Duration` zero value of 0s, which effectively sets the token expiration (`exp`) to 0s.  Some API calls still succeeded though because of the use of this code in a lambda where the cold-start created a new token rather than gathering an existing token from the cache provisioner.

This PR proposes to do two things:
1. set a default TTL of 60m (which is perhaps the controversial bit of this PR - please review and speak your mind!)
2. validates the TTL to ensure it is greater than 0

Opinion on version number for this PR if it goes through as-is?  Fix or minor?