### PR TITLE
Bump httpstats

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	bitbucket.org/atlassian/go-asap v0.0.0-20190921160616-bb88d6193af9
 	github.com/SermoDigital/jose v0.9.2-0.20180104203859-803625baeddc
-	github.com/asecurityteam/httpstats v0.0.0-20200806153718-d71ff7ed1047
+	github.com/asecurityteam/httpstats/v2 v2.4.0
 	github.com/asecurityteam/logevent v1.6.1
 	github.com/asecurityteam/runhttp v0.6.1
 	github.com/asecurityteam/settings v1.0.0
@@ -38,8 +38,8 @@ require (
 	github.com/rs/xstats v0.0.0-20170813190920-c67367528e16 // indirect
 	github.com/rs/zerolog v1.29.0 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
-	golang.org/x/net v0.8.0 // indirect
-	golang.org/x/sys v0.6.0 // indirect
+	golang.org/x/net v0.9.0 // indirect
+	golang.org/x/sys v0.7.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,10 @@ github.com/asecurityteam/component-stat v0.2.0 h1:NT7gw0xK0hcwLv6KjMpFr3SzQE6nHW
 github.com/asecurityteam/component-stat v0.2.0/go.mod h1:VxBlEAdBvRMY9kj5ItlB+VVI3m+e24Xj2yU315eFYEY=
 github.com/asecurityteam/httpstats v0.0.0-20200806153718-d71ff7ed1047 h1:22XPatpbM6Dpbym7jNwUneD7U78gf18xlcP/IOgba1s=
 github.com/asecurityteam/httpstats v0.0.0-20200806153718-d71ff7ed1047/go.mod h1:YzW2Klfs3JFVF8kPxfWt2xscZxgyhCBkcX4IoJO+BbA=
+github.com/asecurityteam/httpstats v0.0.0-20230421142635-11f083214bb1 h1:N6660Ccx/IeMGEsItFmaDg8nYd3/i5KVQOWc7JejVXc=
+github.com/asecurityteam/httpstats v0.0.0-20230421142635-11f083214bb1/go.mod h1:A8G/XeUyH4prkFXeYZc0z9d/FbhA+fMohn8ecBKwDZQ=
+github.com/asecurityteam/httpstats/v2 v2.4.0 h1:7qCoDNeJYEqUBj6BtuePwDI7lh57HcTZ+eLwyrLjEPs=
+github.com/asecurityteam/httpstats/v2 v2.4.0/go.mod h1:vKfLwTs0uLNs406Bz9JMRI/FrdfT0mNy0DWk3hWVJiM=
 github.com/asecurityteam/logevent v1.6.1 h1:D/V11UxgZMBrktTgL3ugRO4hKdBWkz/xLBlpqDq4PoM=
 github.com/asecurityteam/logevent v1.6.1/go.mod h1:wtopE0Pe+072poxy+lGBMah604Uu6/BVwFWRwKwF3TA=
 github.com/asecurityteam/runhttp v0.6.1 h1:dhEOXgbtJ7jgV/4NPfX0Er7deGF5J5ir7qAMRmUG6v0=
@@ -140,6 +144,8 @@ golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.8.0 h1:Zrh2ngAOFYneWTAIAPethzeaQLuHwhuBkuV6ZiRnUaQ=
 golang.org/x/net v0.8.0/go.mod h1:QVkue5JL9kW//ek3r6jTKnTFis1tRmNAW2P1shuFdJc=
+golang.org/x/net v0.9.0 h1:aWJ/m6xSmxWBx+V0XRHTlrYrPG56jKsLdTFmsSsCzOM=
+golang.org/x/net v0.9.0/go.mod h1:d48xBJpPfHeWQsugry2m+kC02ZBRGRgulfHnEXEuWns=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -152,6 +158,8 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.7.0 h1:3jlCCIQZPdOYu1h8BkNvLz8Kgwtae2cagcG/VamtZRU=
+golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/pkg/components/metrics.go
+++ b/pkg/components/metrics.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/asecurityteam/httpstats"
+	"github.com/asecurityteam/httpstats/v2"
 )
 
 // MetricsConfig contains settings for request metrics emissions.


### PR DESCRIPTION
Bumps `httpstats` to v2.4.0. This is a major version upgrade for this library.